### PR TITLE
Aaronmgdr/fix example toggle mobile

### DIFF
--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -276,28 +276,20 @@ export default function Home(): React.ReactElement {
           <ul className="list-disc list-inside">
             {[
               {
-                name: 'Plock',
-                url: 'https://plock.fi',
+                name: 'Celo Tracker ',
+                url: 'https://www.celotracker.com/',
               },
               {
-                name: 'Web multi sig interface',
-                url: 'https://celo-data.nambrot.com/multisig',
+                name: 'Mobius Money',
+                url: 'https://mobius.money/',
               },
               {
-                name: 'Poof Cash',
-                url: 'https://poof.cash',
-              },
-              {
-                name: 'Nomspace',
-                url: 'https://www.nom.space/',
-              },
-              {
-                name: 'Romulus',
-                url: 'https://romulus.page/',
+                name: 'Impact Market',
+                url: 'https://mobius.money/',
               },
               {
                 name: 'Add yours to the list...',
-                url: 'https://github.com/celo-tools/react-celo',
+                url: 'https://github.com/celo-org/react-celo/',
               },
             ].map(({ name, url }) => (
               <li key={name}>

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -200,19 +200,6 @@ export default function Home(): React.ReactElement {
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
       </Head>
-
-      <div className="toggle-dark">
-        <span>Toggle modal's dark mode</span>
-        <label className="switch">
-          <input
-            type="checkbox"
-            onChange={toggleDarkMode}
-            defaultValue={isDark() ? 'checked' : 'unchecked'}
-          />
-          <span className="slider round"></span>
-        </label>
-      </div>
-
       <main>
         <div className="font-semibold text-2xl">react-celo</div>
         <div className="text-slate-600 mt-2">
@@ -338,7 +325,27 @@ export default function Home(): React.ReactElement {
             </a>
           </div>
           <div className="text-slate-600 mb-4">
-            <p>Try out some of the pre-made themes below</p>
+            <h2 className="mb-2 text-lg">Styling</h2>
+            <p className="text-slate-600 mb-4">
+              React Celo will go dark when tailwinds tw-dark class is on body or
+              you can provide a theme
+            </p>
+            <label className="toggle-dark">
+              <span className="toggle-title">
+                Toggle modal's dark mode (tw-dark)
+              </span>
+              <div className="switch">
+                <input
+                  type="checkbox"
+                  onChange={toggleDarkMode}
+                  defaultValue={isDark() ? 'checked' : 'unchecked'}
+                />
+                <span className="slider round"></span>
+              </div>
+            </label>
+            <h3 className="mb-2 text-lg">
+              Try out some of the pre-made themes below
+            </h3>
             <div className="grid grid-flow-col gap-4 my-4">
               {themes.map((theme, i) => (
                 <ThemeButton

--- a/packages/example/styles/global.css
+++ b/packages/example/styles/global.css
@@ -10,21 +10,22 @@
 }
 
 .toggle-dark {
-  position: fixed;
   display: flex;
-  top: 1rem;
-  right: 1rem;
-  z-index: 99999;
+  margin-bottom: 1.5rem;
+  padding: 0.5rem;
 }
-.toggle-dark span:first-child {
-  padding-right: 1rem;
+
+.toggle-title {
+  font-size: 0.88rem;
+  padding-right: 0.67rem;
 }
+
 /* The switch - the box around the slider */
 .switch {
   position: relative;
   display: inline-block;
-  width: 60px;
-  height: 34px;
+  width: 42px;
+  height: 24px;
 }
 /* Hide default HTML checkbox */
 .switch input {
@@ -49,8 +50,8 @@
 .slider:before {
   position: absolute;
   content: '';
-  height: 26px;
-  width: 26px;
+  height: 16px;
+  width: 16px;
   left: 4px;
   bottom: 4px;
   background-color: white;
@@ -67,14 +68,14 @@ input:focus + .slider {
 }
 
 input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+  -webkit-transform: translateX(100%);
+  -ms-transform: translateX(100%);
+  transform: translateX(100%);
 }
 
 /* Rounded sliders */
 .slider.round {
-  border-radius: 34px;
+  border-radius: 20px;
 }
 
 .slider.round:before {


### PR DESCRIPTION
# Fixes overlaping toggle 

Also places the toggle text inside the label for a11y and bigger target. And reduces the toggle size (it was huge compared to everything else)

 *bonus* updates the list of apps that use

## Before
<img width="398" alt="Screen Shot 2022-05-25 at 10 23 06 AM" src="https://user-images.githubusercontent.com/3814795/170325637-152d345b-23de-409b-89ba-63b8a0ffb503.png">

<img width="402" alt="Screen Shot 2022-05-25 at 10 22 54 AM" src="https://user-images.githubusercontent.com/3814795/170325625-4c992fa5-b96a-420e-be33-9d552f068ac8.png">

## After
![Screen Shot 2022-05-25 at 10 24 20 AM](https://user-images.githubusercontent.com/3814795/170325937-c137a16c-8450-4283-a4a5-33b4fd25602d.png)
![Screen Shot 2022-05-25 at 10 24 27 AM](https://user-images.githubusercontent.com/3814795/170325945-5d133d64-c46e-460b-9c03-25c598814123.png)


