### PR TITLE
chore: configure test in example app

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     },
   },
   testEnvironment: 'jsdom',
-  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$',
+  testRegex: '(/__tests__/.*|(\\.|/))(test|spec)\\.[jt]sx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverage: Boolean(process.env.COVERAGE),
   coveragePathIgnorePatterns: ['__tests__', 'lib'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     },
   },
   testEnvironment: 'jsdom',
-  testRegex: '(/__tests__/.*.(test|spec)).(jsx?|tsx?)$',
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverage: Boolean(process.env.COVERAGE),
   coveragePathIgnorePatterns: ['__tests__', 'lib'],

--- a/packages/example/components/test-plan/connect-wallet.test.tsx
+++ b/packages/example/components/test-plan/connect-wallet.test.tsx
@@ -1,0 +1,70 @@
+import '@testing-library/jest-dom';
+
+import { CeloProvider, Mainnet } from '@celo/react-celo';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { generateTestingUtils } from 'eth-testing';
+import { TestingUtils } from 'eth-testing/lib/testing-utils';
+
+import { ConnectWalletCheck } from './connect-wallet';
+
+declare global {
+  interface Window {
+    ethereum: ReturnType<TestingUtils['getProvider']> & { send?: () => void };
+  }
+}
+
+describe('ConnectWalletCheck', () => {
+  const testingUtils = generateTestingUtils({ providerType: 'MetaMask' });
+
+  beforeAll(() => {
+    // Manually inject the mocked provider in the window as MetaMask does
+    const provider = testingUtils.getProvider();
+    global.window.ethereum = provider;
+  });
+
+  beforeEach(() => {
+    testingUtils.clearAllMocks();
+  });
+
+  it('should show success when Metamask is connected', async () => {
+    // Start with no wallet connected
+    testingUtils.mockNotConnectedWallet();
+    // Mock the response for the connection request of MetaMask
+    testingUtils.mockRequestAccounts([
+      '0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf',
+    ]);
+    // `send` is deprecated in Metamask, but web3 still uses it
+    global.window.ethereum.send = jest.fn();
+
+    const screen = render(
+      <CeloProvider
+        dapp={{
+          name: 'Test dapp',
+          description: 'Wallet test plan',
+          url: 'http://localhost:1234',
+          icon: 'http://localhost:1234/favicon.ico',
+        }}
+        network={Mainnet}
+        connectModal={{
+          providersOptions: { searchable: true },
+        }}
+      >
+        <ConnectWalletCheck />
+      </CeloProvider>
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('not started');
+    const runButton = await screen.findByLabelText(
+      'Run Connect wallet to mainnet'
+    );
+    expect(runButton).toBeEnabled();
+
+    fireEvent.click(runButton);
+
+    await waitFor(() => screen.getByText(/MetaMask/).click());
+    await waitFor(() => screen.getByText(/Connected to/, { exact: false }));
+
+    expect(screen.getByRole('status')).toHaveTextContent('success');
+    expect(runButton).toBeDisabled();
+  });
+});

--- a/packages/example/components/test-plan/connect-wallet.tsx
+++ b/packages/example/components/test-plan/connect-wallet.tsx
@@ -24,7 +24,7 @@ export function ConnectWalletCheck() {
   return (
     <TestBlock
       status={status}
-      title="Connect wallet (Mainnet)"
+      title="Connect wallet to mainnet"
       disabledTest={status !== Status.NotStarted}
       onRunTest={onConnectWallet}
     >

--- a/packages/example/components/test-plan/ui.tsx
+++ b/packages/example/components/test-plan/ui.tsx
@@ -9,7 +9,11 @@ export function TestTag({ type }: { type: Status }) {
     return type.replace('-', ' ');
   };
 
-  return <span className={`test-tag ${type}`}>{getText(type)}</span>;
+  return (
+    <span role="status" className={`test-tag ${type}`}>
+      {getText(type)}
+    </span>
+  );
 }
 
 export function TestBlock({
@@ -36,6 +40,7 @@ export function TestBlock({
             className="underline"
             onClick={onRunTest}
             disabled={disabledTest}
+            aria-label={`Run ${title}`}
           >
             Run
           </SecondaryButton>

--- a/packages/example/jest.config.js
+++ b/packages/example/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.js');
+const pkg = require('./package.json');
+
+module.exports = {
+  ...base,
+  displayName: pkg.name,
+  roots: ['<rootDir>'],
+};

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "start": "next start",
-    "export": "next export"
+    "export": "next export",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/example/tsconfig.json
+++ b/packages/example/tsconfig.json
@@ -1,13 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "module": "esnext",
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "sourceMap": true,
-    "incremental": true
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "extends": "./tsconfig.spec.json",
+  "exclude": ["**/*.test.ts"]
 }

--- a/packages/example/tsconfig.spec.json
+++ b/packages/example/tsconfig.spec.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "esnext",
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "sourceMap": true,
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Overview

Sets up tests in the example app, using the configuration from the root (modified only to accept `.test` files outside of `__tests__`).

Part of #164 