### PR TITLE
refactor(useCelo types): make it explicit where types are coming from

### DIFF
--- a/packages/react-celo/src/react-celo-reducer.ts
+++ b/packages/react-celo/src/react-celo-reducer.ts
@@ -106,6 +106,9 @@ export function celoReactReducer(
 
 export interface ReducerState {
   connector: Connector;
+  /**
+   * Initialisation error, if applicable.
+   */
   connectorInitError: Maybe<Error>;
   dapp: Dapp;
   network: Network;

--- a/packages/react-celo/src/types.ts
+++ b/packages/react-celo/src/types.ts
@@ -60,9 +60,15 @@ export interface WalletConnectProvider extends Provider {
 export interface Connector {
   kit: MiniContractKit;
   type: WalletTypes;
+  /**
+   * Name of the account.
+   */
   account: Maybe<string>;
   feeCurrency: CeloTokenContract;
   initialised: boolean;
+  /**
+   * Whether or not the connector has been fully loaded.
+   */
   initialise: () => Promise<this> | this;
   close: () => Promise<void> | void;
   updateFeeCurrency?: (token: CeloTokenContract) => Promise<void>;

--- a/packages/react-celo/src/types.ts
+++ b/packages/react-celo/src/types.ts
@@ -61,13 +61,14 @@ export interface Connector {
   kit: MiniContractKit;
   type: WalletTypes;
   /**
-   * Name of the account.
+   * `account` is the address of the account connected
+   * when there is one. Otherwise, it's null.
    */
   account: Maybe<string>;
   feeCurrency: CeloTokenContract;
   initialised: boolean;
   /**
-   * Whether or not the connector has been fully loaded.
+   * `initialise` indicates whether a connector has been fully loaded.
    */
   initialise: () => Promise<this> | this;
   close: () => Promise<void> | void;

--- a/packages/react-celo/src/types.ts
+++ b/packages/react-celo/src/types.ts
@@ -66,9 +66,14 @@ export interface Connector {
    */
   account: Maybe<string>;
   feeCurrency: CeloTokenContract;
+  /**
+   * `initialised` indicates if the connector
+   * has been fully loaded.
+   */
   initialised: boolean;
   /**
-   * `initialise` indicates whether a connector has been fully loaded.
+   * `initialise` loads the connector
+   *  and saves it to local storage.
    */
   initialise: () => Promise<this> | this;
   close: () => Promise<void> | void;

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -256,13 +256,11 @@ export function useCeloMethods(
 }
 
 export interface CeloMethods {
-  resetInitError: () => void;
   /**
    * `destroy` removes the connection to the wallet from state and from
    * localStorage where it's persisted.
    */
   destroy: () => Promise<void>;
-  initConnector: (connector: Connector) => Promise<void>;
   /**
    * `updateNetwork` changes the network used in the wallet.
    *
@@ -303,4 +301,17 @@ export interface CeloMethods {
    * the user the option to change the theme.
    */
   updateTheme: (theme: Theme | null) => void;
+  /**
+   * @internal
+   * resetInitError cleans up the error that occurred
+   * when trying to initialize a wallet connector.
+   */
+  resetInitError: () => void;
+  /**
+   * @internal
+   *
+   * `initConnector` is used to initialize a connector
+   *  for the wallet chosen by the user.
+   */
+  initConnector: (connector: Connector) => Promise<void>;
 }

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -257,15 +257,50 @@ export function useCeloMethods(
 
 export interface CeloMethods {
   resetInitError: () => void;
+  /**
+   * destroy removes the connection to the wallet from state and from
+   * localStorage where it's persisted.
+   */
   destroy: () => Promise<void>;
   initConnector: (connector: Connector) => Promise<void>;
-  updateNetwork: (network: Network) => Promise<void>;
+  /**
+   * updateNetwork changes the network used in the wallet.
+   *
+   * Note: _not compatible with all wallets_
+   */
+  updateNetwork: (network: Network, forceUpdate?: boolean) => Promise<void>;
+  /**
+   * connect initiates the connection to a wallet and
+   * opens a modal from which the user can choose a
+   * wallet to connect to.
+   */
   connect: () => Promise<Connector>;
+  /**
+   * getConnectedKit gets the connected instance of MiniContractKit.
+   * If the user is not connected, this opens up the connection modal.
+   */
   getConnectedKit: () => Promise<MiniContractKit>;
+  /**
+   * performActions is a helper function for handling any interaction with a Celo wallet.
+   * Perform action will:
+   * - open the action modal
+   * - handle multiple transactions in order
+   */
   performActions: (
     ...operations: ((kit: MiniContractKit) => unknown | Promise<unknown>)[]
   ) => Promise<unknown[]>;
+  /**
+   * updateFeeCurrency updates the currency that will be used
+   * in future transactions.
+   *
+   * Note: _not compatible with all wallets_
+   */
   updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
-  contractsCache?: undefined | unknown;
+  contractsCache?: unknown;
+  /**
+   * updateTheme programmaticaly updates the theme used in the
+   * wallet connection modal. This is useful if you want to give
+   * the user the option to change the theme.
+   */
   updateTheme: (theme: Theme | null) => void;
 }

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -258,30 +258,30 @@ export function useCeloMethods(
 export interface CeloMethods {
   resetInitError: () => void;
   /**
-   * destroy removes the connection to the wallet from state and from
+   * `destroy` removes the connection to the wallet from state and from
    * localStorage where it's persisted.
    */
   destroy: () => Promise<void>;
   initConnector: (connector: Connector) => Promise<void>;
   /**
-   * updateNetwork changes the network used in the wallet.
+   * `updateNetwork` changes the network used in the wallet.
    *
    * Note: _not compatible with all wallets_
    */
   updateNetwork: (network: Network, forceUpdate?: boolean) => Promise<void>;
   /**
-   * connect initiates the connection to a wallet and
+   * `connect` initiates the connection to a wallet and
    * opens a modal from which the user can choose a
    * wallet to connect to.
    */
   connect: () => Promise<Connector>;
   /**
-   * getConnectedKit gets the connected instance of MiniContractKit.
+   * `getConnectedKit` gets the connected instance of MiniContractKit.
    * If the user is not connected, this opens up the connection modal.
    */
   getConnectedKit: () => Promise<MiniContractKit>;
   /**
-   * performActions is a helper function for handling any interaction with a Celo wallet.
+   * `performActions` is a helper function for handling any interaction with a Celo wallet.
    * Perform action will:
    * - open the action modal
    * - handle multiple transactions in order
@@ -290,7 +290,7 @@ export interface CeloMethods {
     ...operations: ((kit: MiniContractKit) => unknown | Promise<unknown>)[]
   ) => Promise<unknown[]>;
   /**
-   * updateFeeCurrency updates the currency that will be used
+   * `updateFeeCurrency` updates the currency that will be used
    * in future transactions.
    *
    * Note: _not compatible with all wallets_
@@ -298,7 +298,7 @@ export interface CeloMethods {
   updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
   contractsCache?: unknown;
   /**
-   * updateTheme programmaticaly updates the theme used in the
+   * `updateTheme` programmaticaly updates the theme used in the
    * wallet connection modal. This is useful if you want to give
    * the user the option to change the theme.
    */

--- a/packages/react-celo/src/use-celo.tsx
+++ b/packages/react-celo/src/use-celo.tsx
@@ -1,119 +1,94 @@
-import { CeloTokenContract } from '@celo/contractkit/lib/base';
-import { MiniContractKit } from '@celo/contractkit/lib/mini-kit';
-
-import { WalletTypes } from './constants';
 import { useReactCeloContext } from './react-celo-provider';
-import { Connector, Dapp, Maybe, Network, Theme } from './types';
+import { ReducerState } from './react-celo-reducer';
+import { CeloMethods } from './use-celo-methods';
 
-export interface UseCelo {
-  dapp: Dapp;
-  kit: MiniContractKit;
-  walletType: WalletTypes;
-  feeCurrency: CeloTokenContract;
+type SomeReducerStateProps = Pick<
+  ReducerState,
+  'dapp' | 'address' | 'network' | 'feeCurrency'
+>;
 
-  /**
-   * Name of the account.
-   */
-  account: Maybe<string>;
+type DerivedFromReducerStateProps = {
+  networks: readonly ReducerState['network'][];
+  initError: ReducerState['connectorInitError'];
+};
 
-  address: Maybe<string>;
-  connect: () => Promise<Connector>;
-  destroy: () => Promise<void>;
-  network: Network;
-  networks: readonly Network[];
-  updateNetwork: (network: Network) => Promise<void>;
-  updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
-  updateTheme: (theme: Theme | null) => void;
-  supportsFeeCurrency: boolean;
-  /**
-   * Helper function for handling any interaction with a Celo wallet. Perform action will
-   * - open the action modal
-   * - handle multiple transactions in order
-   */
-  performActions: (
-    ...operations: ((kit: MiniContractKit) => unknown | Promise<unknown>)[]
-  ) => Promise<unknown[]>;
+type SomeReducerConnectorProps = Pick<
+  ReducerState['connector'],
+  'kit' | 'account' | 'initialised'
+>;
 
-  /**
-   * Whether or not the connector has been fully loaded.
-   */
-  initialised: boolean;
-  /**
-   * Initialisation error, if applicable.
-   */
-  initError: Maybe<Error>;
+type DerivedFromConnectorProps = {
+  supportsFeeCurrency: ReturnType<
+    ReducerState['connector']['supportsFeeCurrency']
+  >;
+  walletType: ReducerState['connector']['type'];
+};
 
-  /**
-   * Gets the connected instance of MiniContractKit.
-   * If the user is not connected, this opens up the connection modal.
-   */
-  getConnectedKit: () => Promise<MiniContractKit>;
-
-  contractsCache?: unknown;
-}
+type SomeCeloMethods = Omit<CeloMethods, 'resetInitError' | 'initConnector'>;
+export type UseCelo = SomeReducerStateProps &
+  DerivedFromReducerStateProps &
+  SomeReducerConnectorProps &
+  DerivedFromConnectorProps &
+  SomeCeloMethods;
 
 export function useCelo<CC = undefined>(): UseCelo {
-  const [
-    {
-      dapp,
-      connector,
-      connectorInitError,
-      address,
-      network,
-      feeCurrency,
-      networks,
-    },
-    _dispatch,
-    {
-      destroy,
-      updateNetwork,
-      connect,
-      getConnectedKit,
-      performActions,
-      updateFeeCurrency,
-      contractsCache,
-      updateTheme,
-    },
-  ] = useReactCeloContext();
+  const [reducerState, _dispatch, celoMethods] = useReactCeloContext();
+
+  const {
+    dapp,
+    address,
+    network,
+    feeCurrency,
+    connectorInitError,
+    networks,
+    connector,
+  } = reducerState;
+
+  const {
+    destroy,
+    updateNetwork,
+    connect,
+    getConnectedKit,
+    performActions,
+    updateFeeCurrency,
+    contractsCache,
+    updateTheme,
+  } = celoMethods;
 
   return {
-    address,
     dapp,
+    address,
     network,
+    feeCurrency,
+    initError: connectorInitError,
     // Copy to ensure any accidental mutations dont affect global state
     networks: networks.map((net) => ({ ...net })),
-    updateNetwork,
+
     kit: connector.kit,
-    contractsCache: contractsCache as CC,
-    walletType: connector.type,
     account: connector.account,
     initialised: connector.initialised,
-    feeCurrency,
-    updateFeeCurrency,
+    walletType: connector.type,
     supportsFeeCurrency: connector.supportsFeeCurrency(),
-    performActions,
-    getConnectedKit,
-    connect,
-    destroy,
-    updateTheme,
 
-    initError: connectorInitError,
+    destroy,
+    updateNetwork,
+    connect,
+    getConnectedKit,
+    performActions,
+    updateFeeCurrency,
+    contractsCache: contractsCache as CC,
+    updateTheme,
   };
 }
 
 /**
- *
  * @deprecated Use the alias {@link useCelo} hook instead.
  */
 export const useContractKit = useCelo;
 
-interface UseCeloInternal extends UseCelo {
-  connectionCallback: Maybe<(connector: Connector | false) => void>;
-  initConnector: (connector: Connector) => Promise<void>;
-  pendingActionCount: number;
-  theme: Maybe<Theme>;
-  resetInitError: () => void;
-}
+type UseCeloInternal = UseCelo &
+  Pick<ReducerState, 'connectionCallback' | 'pendingActionCount' | 'theme'> &
+  Pick<CeloMethods, 'initConnector' | 'resetInitError'>;
 
 /**
  * @internal useCelo with internal methods exposed. Package use only.


### PR DESCRIPTION
### Overview

I noticed we were typing the same types in 3 different places, in the implementation, in the exported types (i.e.: in `CeloMethods`) and then again in `useCelo`. 

The main change is in `packages/react-celo/src/use-celo.tsx`.

This PR focuses on the `useCelo` bit only and the intent is to reuse the existing types in order to:
- avoid repetition
- move documentation closer to where the implementation is
- make it easier to understand where everything that gets returned in `useCelo` is coming from

**Other changes**
- Added a bit more documentation in some of the Celo methods since I had moved other things there.

