### PR TITLE
fix: Celo Utils is not used in react-celo, only in the example app

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@celo/react-celo": "4.0.0-beta.1-dev",
     "@celo/contractkit": "^2.0.0",
+    "@celo/utils": "^2.0.0",
     "next": "^12.1.6",
     "postcss": "^8.4.5",
     "react": "^18.1.0",

--- a/packages/react-celo/package.json
+++ b/packages/react-celo/package.json
@@ -24,7 +24,6 @@
   "readme": "../../readme.md",
   "license": "MIT",
   "dependencies": {
-    "@celo/utils": "^2.0.0",
     "@celo/wallet-base": "^2.0.0",
     "@celo/wallet-ledger": "^2.0.0",
     "@celo/wallet-local": "^2.0.0",


### PR DESCRIPTION
Dependency was listed in wrong package