### PR TITLE
feat: add packages publisher

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.npmjs.org/"

--- a/development.md
+++ b/development.md
@@ -1,0 +1,63 @@
+# Development
+
+## Workflow
+
+To run all the packages locally at once, simply clone this repository and run:
+
+```sh
+yarn;
+yarn build;  #only needs to be run the first time
+yarn dev;
+```
+
+A hot reloading server should come up on localhost:3000, it's the exact same as what's at react-celo-c-labs.vercel.app.
+
+Alternatively, you can individually run `react-celo` and the `example` app in parallel.
+
+For that, you still need to have run `yarn` in the root.
+
+Then, you can run `react-celo` in one tab:
+
+```sh
+cd packages/react-celo
+yarn dev
+```
+
+and run the `example` app in another:
+
+```sh
+cd packages/example
+yarn dev
+```
+
+## Bumping the packages
+
+All packages under `/packages` are meant to published with the same version.
+
+To bump the version of all the packages at once, use the `bump-versions` script.
+You'll need to specify which semver increase you want to use.
+
+For example, to bump to a prerelease:
+
+```sh
+yarn bump-versions prerelease --preId alpha
+```
+
+or for bumping a `major` version (same for `minor` or `patch`):
+
+```sh
+yarn bump-versions major
+```
+
+## Publishing the packages
+
+Once the packages are ready to be published, ensure you've checked master and it is updated. Then, you can run the npm following npm script:
+
+```sh
+yarn publish-packages
+```
+
+Hint:
+
+- You can use the `--dry-run` flag to check everything would run properly
+- If you need to run the script multiple times without changing the code, using the `--skip-build` flag can be useful to reduce the time.

--- a/development.md
+++ b/development.md
@@ -10,7 +10,7 @@ yarn build;  #only needs to be run the first time
 yarn dev;
 ```
 
-A hot reloading server should come up on localhost:3000, it's the exact same as what's at react-celo-c-labs.vercel.app.
+A hot reloading server should come up on localhost:3000, it's the exact same as what's at react-celo-canary.vercel.app.
 
 Alternatively, you can individually run `react-celo` and the `example` app in parallel.
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "lerna link && COVERAGE=ON lerna run --stream --no-bail test",
     "prepare": "husky install",
     "reset-modules": "rm -rf node_modules/ packages/*/node_modules",
+    "publish-packages-script": "ts-node ./scripts/publish-packages.ts",
     "deprecate-version": "ts-node ./scripts/deprecate-version.ts",
     "publish-packages": "pkgs publish",
     "bump-versions": "pkgs bump-versions"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "workspaces": [
     "packages/*"
   ],
+  "pkgs": {
+    "path": "./packages"
+  },
   "scripts": {
     "dev": "lerna run dev --stream --parallel",
     "build": "lerna link && lerna run clean && lerna run build --scope 'example' --include-dependencies",
@@ -13,10 +16,12 @@
     "test": "lerna link && COVERAGE=ON lerna run --stream --no-bail test",
     "prepare": "husky install",
     "reset-modules": "rm -rf node_modules/ packages/*/node_modules",
-    "publish-packages": "ts-node ./scripts/publish-packages.ts",
-    "deprecate-version": "ts-node ./scripts/deprecate-version.ts"
+    "deprecate-version": "ts-node ./scripts/deprecate-version.ts",
+    "publish-packages": "pkgs publish",
+    "bump-versions": "pkgs bump-versions"
   },
   "devDependencies": {
+    "@clabs/packages-publisher": "^0.0.1-alpha.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@types/jest": "^27.5.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bump-versions": "pkgs bump-versions"
   },
   "devDependencies": {
-    "@clabs/packages-publisher": "^0.0.1-alpha.2",
+    "@clabs/packages-publisher": "0.0.1-alpha.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@types/jest": "^27.5.1",

--- a/readme.md
+++ b/readme.md
@@ -365,36 +365,6 @@ interface Theme {
 }
 ```
 
-## Development
-
-To run all the packages locally at once, simply clone this repository and run:
-
-```sh
-yarn;
-yarn build;  #only needs to be run the first time
-yarn dev;
-```
-
-A hot reloading server should come up on localhost:3000, it's the exact same as what's at react-celo-c-labs.vercel.app.
-
-Alternatively, you can individually run `react-celo` and the `example` app in parallel.
-
-For that, you still need to have run `yarn` in the root.
-
-Then, you can run `react-celo` in one tab:
-
-```sh
-cd packages/react-celo
-yarn dev
-```
-
-and run the `example` app in another:
-
-```sh
-cd packages/example
-yarn dev
-```
-
 ## Support
 
 Struggling with anything react-celo related? Jump into the [GitHub Discussions](https://github.com/celo-org/react-celo/discussions) or [celo-org discord channel](https://chat.celo.org) and ask for help any time.

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,10 +642,10 @@
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"
 
-"@clabs/packages-publisher@^0.0.1-alpha.2":
-  version "0.0.1-alpha.2"
-  resolved "https://registry.npmjs.org/@clabs/packages-publisher/-/packages-publisher-0.0.1-alpha.2.tgz#e1a8b3958d8a87397e7f2b0bbf6ed177a561bd95"
-  integrity sha512-ynm7U6Y8Cu63mHQKdGODlX51oPBxSCnkQBDNcpNVFNEbjLD5KJkvGCtWjG+ESBZU7oK4BGnHkYjDqHkZG5wDIQ==
+"@clabs/packages-publisher@0.0.1-alpha.3":
+  version "0.0.1-alpha.3"
+  resolved "https://registry.npmjs.org/@clabs/packages-publisher/-/packages-publisher-0.0.1-alpha.3.tgz#fbaf6866e3751ada30cb6e2e8d622bfa97c86a4b"
+  integrity sha512-ooxBTiRStigZFaGSF4SlAW20t7aA/y22D04QcEN0aAMR3JUFfOZ4CDBw/zZjmt94dbM315I+cfAZF2aJjwyENA==
   dependencies:
     execa "5.1.1"
     kleur "^4.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,17 @@
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"
 
+"@clabs/packages-publisher@^0.0.1-alpha.2":
+  version "0.0.1-alpha.2"
+  resolved "https://registry.npmjs.org/@clabs/packages-publisher/-/packages-publisher-0.0.1-alpha.2.tgz#e1a8b3958d8a87397e7f2b0bbf6ed177a561bd95"
+  integrity sha512-ynm7U6Y8Cu63mHQKdGODlX51oPBxSCnkQBDNcpNVFNEbjLD5KJkvGCtWjG+ESBZU7oK4BGnHkYjDqHkZG5wDIQ==
+  dependencies:
+    execa "5.1.1"
+    kleur "^4.1.4"
+    prompts "^2.4.2"
+    semver "^7.3.6"
+    yargs "^17.4.1"
+
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"
@@ -5850,7 +5861,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-execa@^5.0.0, execa@^5.1.1:
+execa@5.1.1, execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -7834,6 +7845,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kleur@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.4.tgz#8c202987d7e577766d039a8cd461934c01cda04d"
+  integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
+
 lerna@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-4.0.0.tgz#b139d685d50ea0ca1be87713a7c2f44a5b678e9e"
@@ -9517,7 +9533,7 @@ prompt@^1.2.1:
     revalidator "0.1.x"
     winston "2.x"
 
-prompts@^2.0.1:
+prompts@^2.0.1, prompts@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
@@ -10197,6 +10213,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.6:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -12310,6 +12333,19 @@ yargs@^17.3.1:
   version "17.5.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.0.tgz#2706c5431f8c119002a2b106fc9f58b9bb9097a3"
   integrity sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
+
+yargs@^17.4.1:
+  version "17.5.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
+  integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
Addresses #232 

### Overview

Introduces the `@clabs/packages-publisher` so we can start testing it for publishing packages. Note that the tool is in alpha because I think we need to use it a couple of times and check where it fails.

Bear in mind that the tool expects the versions to NOT contain `dev` suffix, so before publishing, you'll need to run the `bump-versions` tool. 

Then, to add back `dev` in the version, you'll need to run the `bump-versions` again, but this time forcing `dev` to be used:
```
yarn cli:dev-run bump-versions prerelease --preId dev --forcePreId
```

### Up for discussion

I think it'd be useful to agree on whether we'll continue to use `dev` in the version or not, and what's the ideal workflow. As I mentioned, I think we should drop `dev` and use regular semver versioning. If we want to split `dev` vs `published`, we could use something like a git workflow where we have a separate branch for developing that.