### PR TITLE
remove ethereumjs utils

### DIFF
--- a/packages/walletconnect-v1/__tests__/utils/common.ts
+++ b/packages/walletconnect-v1/__tests__/utils/common.ts
@@ -2,8 +2,7 @@ import { Address } from '@celo/base';
 import { CeloTx } from '@celo/connect';
 import { newKit } from '@celo/contractkit/lib/mini-kit';
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
-import { toChecksumAddress } from 'ethereumjs-util';
-
+import { toChecksumAddress } from '@walletconnect/utils-v1';
 // personal_sign is the one RPC that has [payload, from] rather
 // than [from, payload]
 export function parsePersonalSign(params: [string, string]): {

--- a/packages/walletconnect-v1/jest.config.js
+++ b/packages/walletconnect-v1/jest.config.js
@@ -3,6 +3,5 @@ const pkg = require('./package.json');
 
 module.exports = {
   ...base,
-  name: pkg.name,
   displayName: pkg.name,
 };

--- a/packages/walletconnect-v1/package.json
+++ b/packages/walletconnect-v1/package.json
@@ -29,8 +29,7 @@
     "@walletconnect/client-v1": "npm:@walletconnect/client@1.6.6",
     "@walletconnect/types-v1": "npm:@walletconnect/types@1.6.6",
     "@walletconnect/utils-v1": "npm:@walletconnect/utils@1.6.6",
-    "debug": "^4.3.3",
-    "ethereumjs-util": "^7.1.3"
+    "debug": "^4.3.3"
   },
   "engines": {
     "node": ">=10"

--- a/packages/walletconnect-v1/src/utils/from-rpc-sig.test.ts
+++ b/packages/walletconnect-v1/src/utils/from-rpc-sig.test.ts
@@ -1,0 +1,40 @@
+import { fromRpcSig } from './from-rpc-sig';
+
+describe('fromRpcSig', () => {
+  const r = Buffer.from(
+    '99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9',
+    'hex'
+  );
+  const s = Buffer.from(
+    '129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66',
+    'hex'
+  );
+  it('converts', () => {
+    const sig =
+      '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca661b';
+
+    expect(fromRpcSig(sig)).toMatchObject({
+      v: 27,
+      r,
+      s,
+    });
+  });
+  it('throws when length is short', () => {
+    expect(() => fromRpcSig('')).toThrow();
+    expect(() =>
+      fromRpcSig(
+        '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364'
+      )
+    ).toThrow();
+  });
+
+  it('supports EIP-2098', () => {
+    const sig =
+      '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9929ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66';
+    expect(fromRpcSig(sig)).toMatchObject({
+      v: 28,
+      r,
+      s,
+    });
+  });
+});

--- a/packages/walletconnect-v1/src/utils/from-rpc-sig.ts
+++ b/packages/walletconnect-v1/src/utils/from-rpc-sig.ts
@@ -10,6 +10,7 @@ export interface ECDSASignature {
  *
  * Convert signature format of the `eth_sign` RPC method to signature parameters
  * Borrowed from ethereumjs https://github.com/ethereumjs/ethereumjs-monorepo/blob/ade4233ddffffdd146b386de701762196a8c941c/packages/util/src/signature.ts
+ * Copyright ethereumjs License: https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/LICENSE
  * NOTE: all because of a bug in geth: https://github.com/ethereum/go-ethereum/issues/2053
  */
 export const fromRpcSig = function (sig: string): ECDSASignature {

--- a/packages/walletconnect-v1/src/utils/fromRPCsig.ts
+++ b/packages/walletconnect-v1/src/utils/fromRPCsig.ts
@@ -1,0 +1,87 @@
+import { convertBufferToNumber } from '@walletconnect/utils-v1';
+
+export interface ECDSASignature {
+  v: number;
+  r: Buffer;
+  s: Buffer;
+}
+
+/**
+ *
+ * Convert signature format of the `eth_sign` RPC method to signature parameters
+ * Borrowed from ethereumjs https://github.com/ethereumjs/ethereumjs-monorepo/blob/ade4233ddffffdd146b386de701762196a8c941c/packages/util/src/signature.ts
+ * NOTE: all because of a bug in geth: https://github.com/ethereum/go-ethereum/issues/2053
+ */
+export const fromRpcSig = function (sig: string): ECDSASignature {
+  const buf: Buffer = stringToBuffer(sig);
+
+  let r: Buffer;
+  let s: Buffer;
+  let v: number;
+  if (buf.length >= 65) {
+    r = buf.slice(0, 32);
+    s = buf.slice(32, 64);
+    v = convertBufferToNumber(buf.slice(64));
+  } else if (buf.length === 64) {
+    // Compact Signature Representation (https://eips.ethereum.org/EIPS/eip-2098)
+    r = buf.slice(0, 32);
+    s = buf.slice(32, 64);
+    v = convertBufferToNumber(buf.slice(32, 33)) >> 7;
+    s[0] &= 0x7f;
+  } else {
+    throw new Error('Invalid signature length');
+  }
+
+  // support both versions of `eth_sign` responses
+  if (v < 27) {
+    v += 27;
+  }
+
+  return {
+    v,
+    r,
+    s,
+  };
+};
+
+function stringToBuffer(v: string) {
+  if (v === null || v === undefined) {
+    return Buffer.allocUnsafe(0);
+  }
+
+  if (Buffer.isBuffer(v)) {
+    return Buffer.from(v);
+  }
+
+  if (typeof v === 'string') {
+    if (!isHexString(v)) {
+      throw new Error(
+        `Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: ${v}`
+      );
+    }
+    return Buffer.from(padToEven(stripHexPrefix(v)), 'hex');
+  }
+
+  throw new Error('invalid type');
+}
+
+function stripHexPrefix(value: string) {
+  return isHexString(value) ? value.slice(2) : value;
+}
+
+function isHexString(str: string) {
+  if (typeof str !== 'string') {
+    throw new Error(
+      `[stripHexPrefix] input must be type 'string', received ${typeof str}`
+    );
+  }
+  return str.startsWith('0x');
+}
+
+function padToEven(value: string) {
+  if (value.length % 2) {
+    return `0${value}`;
+  }
+
+  return value;
+}

--- a/packages/walletconnect-v1/src/wc-signer.ts
+++ b/packages/walletconnect-v1/src/wc-signer.ts
@@ -3,7 +3,7 @@ import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
 import WalletConnect from '@walletconnect/client-v1';
 
 import { SupportedMethods, WCSession } from './types';
-import { ECDSASignature, fromRpcSig } from './utils/fromRPCsig';
+import { ECDSASignature, fromRpcSig } from './utils/from-rpc-sig';
 
 /**
  * Implements the signer interface on top of the WalletConnect interface.

--- a/packages/walletconnect-v1/src/wc-signer.ts
+++ b/packages/walletconnect-v1/src/wc-signer.ts
@@ -1,9 +1,9 @@
 import { CeloTx, EncodedTransaction, Signer } from '@celo/connect';
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
 import WalletConnect from '@walletconnect/client-v1';
-import * as ethUtil from 'ethereumjs-util';
 
 import { SupportedMethods, WCSession } from './types';
+import { ECDSASignature, fromRpcSig } from './utils/fromRPCsig';
 
 /**
  * Implements the signer interface on top of the WalletConnect interface.
@@ -38,24 +38,20 @@ export class WalletConnectSigner implements Signer {
     return signedTx;
   }
 
-  async signTypedData(
-    data: EIP712TypedData
-  ): Promise<ReturnType<typeof ethUtil.fromRpcSig>> {
+  async signTypedData(data: EIP712TypedData): Promise<ECDSASignature> {
     const signature = await this.request<string>(
       SupportedMethods.signTypedData,
       [this.getNativeKey(), JSON.stringify(data)]
     );
-    return ethUtil.fromRpcSig(signature);
+    return fromRpcSig(signature);
   }
 
-  async signPersonalMessage(
-    data: string
-  ): Promise<ReturnType<typeof ethUtil.fromRpcSig>> {
+  async signPersonalMessage(data: string): Promise<ECDSASignature> {
     const signature = await this.request<string>(
       SupportedMethods.personalSign,
       [data, this.getNativeKey()]
     );
-    return ethUtil.fromRpcSig(signature);
+    return fromRpcSig(signature);
   }
 
   getNativeKey = (): string => this.account;


### PR DESCRIPTION
ethereumjs-util was only used in 2 places. 

remove by using equivalent function from wallet connect and inlining ethereumjs-utils `fromRPCsig` with some modifications. for instance original took many types, in this case we only accept a string as input. 