### PR TITLE
Typed Local Storage

### DIFF
--- a/packages/react-celo/__tests__/connectors/ledger.test.ts
+++ b/packages/react-celo/__tests__/connectors/ledger.test.ts
@@ -1,7 +1,13 @@
 import { CeloContract } from '@celo/contractkit';
 
-import { Alfajores, localStorageKeys, WalletTypes } from '../../src';
+import { Alfajores, WalletTypes } from '../../src';
 import { LedgerConnector } from '../../src/connectors';
+import {
+  getLastUsedFeeCurrency,
+  getLastUsedNetwork,
+  getLastUsedWalletArgs,
+  getLastUsedWalletType,
+} from '../../src/utils/localStorage';
 
 describe('LedgerConnector', () => {
   let connector: LedgerConnector;
@@ -10,38 +16,24 @@ describe('LedgerConnector', () => {
   });
 
   it('remembers info in localStorage', () => {
-    expect(localStorage.getItem(localStorageKeys.lastUsedFeeCurrency)).toEqual(
-      null
-    );
+    expect(getLastUsedFeeCurrency()).toEqual(null);
 
-    expect(localStorage.getItem(localStorageKeys.lastUsedWalletType)).toEqual(
-      WalletTypes.Ledger
-    );
+    expect(getLastUsedWalletType()).toEqual(WalletTypes.Ledger);
 
-    expect(
-      localStorage.getItem(localStorageKeys.lastUsedWalletArguments)
-    ).toEqual('[0]');
+    expect(getLastUsedWalletArgs()).toEqual([0]);
 
-    expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
-      'Alfajores'
-    );
+    expect(getLastUsedNetwork()).toEqual('Alfajores');
   });
 
   describe('close()', () => {
     it('clears out localStorage', () => {
       connector.close();
 
-      expect(
-        localStorage.getItem(localStorageKeys.lastUsedFeeCurrency)
-      ).toEqual(null);
+      expect(getLastUsedFeeCurrency()).toEqual(null);
 
-      expect(
-        localStorage.getItem(localStorageKeys.lastUsedWalletArguments)
-      ).toEqual(null);
+      expect(getLastUsedWalletArgs()).toEqual(null);
 
-      expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
-        null
-      );
+      expect(getLastUsedNetwork()).toEqual(null);
     });
   });
   describe('updateFeeCurrency', () => {

--- a/packages/react-celo/__tests__/connectors/ledger.test.ts
+++ b/packages/react-celo/__tests__/connectors/ledger.test.ts
@@ -1,12 +1,10 @@
 import { CeloContract } from '@celo/contractkit';
 
-import { Alfajores, WalletTypes } from '../../src';
+import { Alfajores, localStorageKeys, WalletTypes } from '../../src';
 import { LedgerConnector } from '../../src/connectors';
 import {
-  getLastUsedFeeCurrency,
-  getLastUsedNetwork,
   getLastUsedWalletArgs,
-  getLastUsedWalletType,
+  getTypedStorageKey,
 } from '../../src/utils/localStorage';
 
 describe('LedgerConnector', () => {
@@ -16,24 +14,34 @@ describe('LedgerConnector', () => {
   });
 
   it('remembers info in localStorage', () => {
-    expect(getLastUsedFeeCurrency()).toEqual(null);
+    expect(getTypedStorageKey(localStorageKeys.lastUsedFeeCurrency)).toEqual(
+      null
+    );
 
-    expect(getLastUsedWalletType()).toEqual(WalletTypes.Ledger);
+    expect(getTypedStorageKey(localStorageKeys.lastUsedWalletType)).toEqual(
+      WalletTypes.Ledger
+    );
+
+    expect(getTypedStorageKey(localStorageKeys.lastUsedNetwork)).toEqual(
+      'Alfajores'
+    );
 
     expect(getLastUsedWalletArgs()).toEqual([0]);
-
-    expect(getLastUsedNetwork()).toEqual('Alfajores');
   });
 
   describe('close()', () => {
     it('clears out localStorage', () => {
       connector.close();
 
-      expect(getLastUsedFeeCurrency()).toEqual(null);
+      expect(getTypedStorageKey(localStorageKeys.lastUsedFeeCurrency)).toEqual(
+        null
+      );
 
       expect(getLastUsedWalletArgs()).toEqual(null);
 
-      expect(getLastUsedNetwork()).toEqual(null);
+      expect(getTypedStorageKey(localStorageKeys.lastUsedNetwork)).toEqual(
+        null
+      );
     });
   });
   describe('updateFeeCurrency', () => {

--- a/packages/react-celo/__tests__/connectors/metamask.test.ts
+++ b/packages/react-celo/__tests__/connectors/metamask.test.ts
@@ -1,9 +1,10 @@
 import { CeloContract } from '@celo/contractkit/lib/base';
 import { generateTestingUtils } from 'eth-testing';
 
+import { localStorageKeys } from '../../src';
 import { MetaMaskConnector } from '../../src/connectors';
 import { Alfajores, Baklava } from '../../src/constants';
-import { getLastUsedNetwork } from '../../src/utils/localStorage';
+import { getTypedStorageKey } from '../../src/utils/localStorage';
 
 const ACCOUNT = '0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf';
 
@@ -42,7 +43,9 @@ describe('MetaMaskConnector', () => {
     it('sets network in local storage and in connection', async () => {
       await connector.updateKitWithNetwork(Baklava);
 
-      expect(getLastUsedNetwork()).toEqual(Baklava.name);
+      expect(getTypedStorageKey(localStorageKeys.lastUsedNetwork)).toEqual(
+        Baklava.name
+      );
     });
 
     const callback = jest.fn();

--- a/packages/react-celo/__tests__/connectors/metamask.test.ts
+++ b/packages/react-celo/__tests__/connectors/metamask.test.ts
@@ -2,8 +2,8 @@ import { CeloContract } from '@celo/contractkit/lib/base';
 import { generateTestingUtils } from 'eth-testing';
 
 import { MetaMaskConnector } from '../../src/connectors';
-import { Alfajores, Baklava, localStorageKeys } from '../../src/constants';
-import localStorage from '../../src/utils/localStorage';
+import { Alfajores, Baklava } from '../../src/constants';
+import { getLastUsedNetwork } from '../../src/utils/localStorage';
 
 const ACCOUNT = '0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf';
 
@@ -42,9 +42,7 @@ describe('MetaMaskConnector', () => {
     it('sets network in local storage and in connection', async () => {
       await connector.updateKitWithNetwork(Baklava);
 
-      expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
-        Baklava.name
-      );
+      expect(getLastUsedNetwork()).toEqual(Baklava.name);
     });
 
     const callback = jest.fn();

--- a/packages/react-celo/__tests__/connectors/private-key.test.ts
+++ b/packages/react-celo/__tests__/connectors/private-key.test.ts
@@ -1,11 +1,10 @@
 import { CeloContract } from '@celo/contractkit';
 
-import { Alfajores } from '../../src';
+import { Alfajores, localStorageKeys } from '../../src';
 import { PrivateKeyConnector } from '../../src/connectors';
 import {
-  getLastUsedFeeCurrency,
-  getLastUsedNetwork,
   getLastUsedWalletArgs,
+  getTypedStorageKey,
 } from '../../src/utils/localStorage';
 
 const TEST_KEY =
@@ -40,7 +39,9 @@ describe('PrivateKeyConnector', () => {
     });
 
     it('sets the last network in local storage', () => {
-      expect(getLastUsedNetwork()).toEqual(Alfajores.name);
+      expect(getTypedStorageKey(localStorageKeys.lastUsedNetwork)).toEqual(
+        Alfajores.name
+      );
     });
   });
 
@@ -55,11 +56,17 @@ describe('PrivateKeyConnector', () => {
 
       connector.close();
 
-      expect(getLastUsedFeeCurrency()).toEqual(null);
+      expect(getTypedStorageKey(localStorageKeys.lastUsedFeeCurrency)).toEqual(
+        null
+      );
 
-      expect(getLastUsedWalletArgs()).toEqual(null);
+      expect(
+        getTypedStorageKey(localStorageKeys.lastUsedWalletArguments)
+      ).toEqual(null);
 
-      expect(getLastUsedNetwork()).toEqual(null);
+      expect(getTypedStorageKey(localStorageKeys.lastUsedNetwork)).toEqual(
+        null
+      );
     });
   });
   describe('updateFeeCurrency', () => {

--- a/packages/react-celo/__tests__/connectors/private-key.test.ts
+++ b/packages/react-celo/__tests__/connectors/private-key.test.ts
@@ -1,7 +1,12 @@
 import { CeloContract } from '@celo/contractkit';
 
-import { Alfajores, localStorageKeys } from '../../src';
+import { Alfajores } from '../../src';
 import { PrivateKeyConnector } from '../../src/connectors';
+import {
+  getLastUsedFeeCurrency,
+  getLastUsedNetwork,
+  getLastUsedWalletArgs,
+} from '../../src/utils/localStorage';
 
 const TEST_KEY =
   '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abbdef';
@@ -31,15 +36,11 @@ describe('PrivateKeyConnector', () => {
     });
 
     it('sets the private key in locale storage', () => {
-      expect(
-        localStorage.getItem(localStorageKeys.lastUsedWalletArguments)
-      ).toEqual(JSON.stringify([TEST_KEY]));
+      expect(getLastUsedWalletArgs()).toEqual([TEST_KEY]);
     });
 
     it('sets the last network in local storage', () => {
-      expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
-        Alfajores.name
-      );
+      expect(getLastUsedNetwork()).toEqual(Alfajores.name);
     });
   });
 
@@ -54,17 +55,11 @@ describe('PrivateKeyConnector', () => {
 
       connector.close();
 
-      expect(
-        localStorage.getItem(localStorageKeys.lastUsedFeeCurrency)
-      ).toEqual(null);
+      expect(getLastUsedFeeCurrency()).toEqual(null);
 
-      expect(
-        localStorage.getItem(localStorageKeys.lastUsedWalletArguments)
-      ).toEqual(null);
+      expect(getLastUsedWalletArgs()).toEqual(null);
 
-      expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
-        null
-      );
+      expect(getLastUsedNetwork()).toEqual(null);
     });
   });
   describe('updateFeeCurrency', () => {

--- a/packages/react-celo/__tests__/utils/react-celo-reducer.test.ts
+++ b/packages/react-celo/__tests__/utils/react-celo-reducer.test.ts
@@ -1,8 +1,9 @@
 import { CeloContract } from '@celo/contractkit';
 
 import { UnauthenticatedConnector } from '../../src/connectors';
-import { Alfajores, Baklava, localStorageKeys } from '../../src/constants';
+import { Alfajores, Baklava } from '../../src/constants';
 import { celoReactReducer, ReducerState } from '../../src/react-celo-reducer';
+import { getLastUsedAddress } from '../../src/utils/localStorage';
 
 const initialState: ReducerState = {
   connector: new UnauthenticatedConnector(Alfajores),
@@ -34,9 +35,7 @@ describe('setAddress', () => {
     expect(newState).toEqual({ ...initialState, address: 'test-address' });
   });
   it('saves the address in localStorage', () => {
-    expect(localStorage.getItem(localStorageKeys.lastUsedAddress)).toEqual(
-      'test-address'
-    );
+    expect(getLastUsedAddress()).toEqual('test-address');
   });
 });
 

--- a/packages/react-celo/__tests__/utils/react-celo-reducer.test.ts
+++ b/packages/react-celo/__tests__/utils/react-celo-reducer.test.ts
@@ -1,9 +1,10 @@
 import { CeloContract } from '@celo/contractkit';
 
+import { localStorageKeys } from '../../src';
 import { UnauthenticatedConnector } from '../../src/connectors';
 import { Alfajores, Baklava } from '../../src/constants';
 import { celoReactReducer, ReducerState } from '../../src/react-celo-reducer';
-import { getLastUsedAddress } from '../../src/utils/localStorage';
+import { getTypedStorageKey } from '../../src/utils/localStorage';
 
 const initialState: ReducerState = {
   connector: new UnauthenticatedConnector(Alfajores),
@@ -35,7 +36,9 @@ describe('setAddress', () => {
     expect(newState).toEqual({ ...initialState, address: 'test-address' });
   });
   it('saves the address in localStorage', () => {
-    expect(getLastUsedAddress()).toEqual('test-address');
+    expect(getTypedStorageKey(localStorageKeys.lastUsedAddress)).toEqual(
+      'test-address'
+    );
   });
 });
 

--- a/packages/react-celo/src/connectors/connectors.ts
+++ b/packages/react-celo/src/connectors/connectors.ts
@@ -16,16 +16,14 @@ import {
 } from '@celo/wallet-walletconnect-v1';
 import { BigNumber } from 'bignumber.js';
 
-import { WalletTypes } from '../constants';
+import { localStorageKeys, WalletTypes } from '../constants';
 import { Connector, Maybe, Network } from '../types';
 import { getEthereum, getInjectedEthereum } from '../utils/ethereum';
 import {
   clearPreviousConfig,
   forgetConnection,
-  setLastUsedNetwork,
   setLastUsedWalletArgs,
-  setLastUsedWalletId,
-  setLastUsedWalletType,
+  setTypedStorageKey,
   WalletArgs,
 } from '../utils/localStorage';
 import { switchToCeloNetwork } from '../utils/metamask';
@@ -127,9 +125,9 @@ export class LedgerConnector implements Connector {
     private index: number,
     public feeCurrency: CeloTokenContract
   ) {
-    setLastUsedWalletType(WalletTypes.Ledger);
     setLastUsedWalletArgs([index]);
-    setLastUsedNetwork(network.name);
+    setTypedStorageKey(localStorageKeys.lastUsedWalletType, WalletTypes.Ledger);
+    setTypedStorageKey(localStorageKeys.lastUsedNetwork, network.name);
     this.kit = newKit(network.rpcUrl);
   }
 
@@ -258,7 +256,7 @@ export class InjectedConnector implements Connector {
   }
 
   async updateKitWithNetwork(network: Network): Promise<void> {
-    setLastUsedNetwork(network.name);
+    setTypedStorageKey(localStorageKeys.lastUsedNetwork, network.name);
     this.network = network;
     await this.initialise();
   }
@@ -516,13 +514,13 @@ function persist({
   network?: Network;
 }): void {
   if (walletType) {
-    setLastUsedWalletType(walletType);
+    setTypedStorageKey(localStorageKeys.lastUsedWalletType, walletType);
   }
   if (walletId) {
-    setLastUsedWalletId(walletId);
+    setTypedStorageKey(localStorageKeys.lastUsedWalletId, walletId);
   }
   if (network) {
-    setLastUsedNetwork(network.name);
+    setTypedStorageKey(localStorageKeys.lastUsedNetwork, network.name);
   }
   setLastUsedWalletArgs(options);
 }

--- a/packages/react-celo/src/connectors/connectors.ts
+++ b/packages/react-celo/src/connectors/connectors.ts
@@ -17,11 +17,18 @@ import {
 } from '@celo/wallet-walletconnect-v1';
 import { BigNumber } from 'bignumber.js';
 
-import { localStorageKeys, WalletTypes } from '../constants';
+import { WalletTypes } from '../constants';
 import { Connector, Maybe, Network } from '../types';
 import { getEthereum, getInjectedEthereum } from '../utils/ethereum';
-import { clearPreviousConfig } from '../utils/helpers';
-import localStorage from '../utils/localStorage';
+import {
+  clearPreviousConfig,
+  forgetConnection,
+  setLastUsedNetwork,
+  setLastUsedWalletArgs,
+  setLastUsedWalletId,
+  setLastUsedWalletType,
+  WalletArgs,
+} from '../utils/localStorage';
 import { switchToCeloNetwork } from '../utils/metamask';
 
 type Web3Type = Parameters<typeof newKitFromWeb3>[0];
@@ -43,9 +50,7 @@ export class UnauthenticatedConnector implements Connector {
   }
 
   persist() {
-    localStorage.removeItem(localStorageKeys.lastUsedWalletType);
-    localStorage.removeItem(localStorageKeys.lastUsedWalletArguments);
-    localStorage.removeItem(localStorageKeys.lastUsedNetwork);
+    forgetConnection();
   }
 
   initialise(): this {
@@ -123,15 +128,9 @@ export class LedgerConnector implements Connector {
     private index: number,
     public feeCurrency: CeloTokenContract
   ) {
-    localStorage.setItem(
-      localStorageKeys.lastUsedWalletType,
-      WalletTypes.Ledger
-    );
-    localStorage.setItem(
-      localStorageKeys.lastUsedWalletArguments,
-      JSON.stringify([index])
-    );
-    localStorage.setItem(localStorageKeys.lastUsedNetwork, network.name);
+    setLastUsedWalletType(WalletTypes.Ledger);
+    setLastUsedWalletArgs([index]);
+    setLastUsedNetwork(network.name);
     this.kit = newKit(network.rpcUrl);
   }
 
@@ -260,7 +259,7 @@ export class InjectedConnector implements Connector {
   }
 
   async updateKitWithNetwork(network: Network): Promise<void> {
-    localStorage.setItem(localStorageKeys.lastUsedNetwork, network.name);
+    setLastUsedNetwork(network.name);
     this.network = network;
     await this.initialise();
   }
@@ -514,20 +513,17 @@ function persist({
 }: {
   walletType?: WalletTypes;
   walletId?: string;
-  options?: unknown[];
+  options?: WalletArgs;
   network?: Network;
 }): void {
   if (walletType) {
-    localStorage.setItem(localStorageKeys.lastUsedWalletType, walletType);
+    setLastUsedWalletType(walletType);
   }
   if (walletId) {
-    localStorage.setItem(localStorageKeys.lastUsedWalletId, walletId);
+    setLastUsedWalletId(walletId);
   }
   if (network) {
-    localStorage.setItem(localStorageKeys.lastUsedNetwork, network.name);
+    setLastUsedNetwork(network.name);
   }
-  localStorage.setItem(
-    localStorageKeys.lastUsedWalletArguments,
-    JSON.stringify(options)
-  );
+  setLastUsedWalletArgs(options);
 }

--- a/packages/react-celo/src/connectors/connectors.ts
+++ b/packages/react-celo/src/connectors/connectors.ts
@@ -1,4 +1,3 @@
-import { ReadOnlyWallet } from '@celo/connect/lib';
 import { CeloContract, CeloTokenContract } from '@celo/contractkit/lib/base';
 import {
   MiniContractKit,
@@ -386,7 +385,7 @@ export class WalletConnectConnector implements Connector {
     // version == 1
     //   ? new WalletConnectWalletV1(options as WalletConnectWalletOptionsV1)
     //   : new WalletConnectWallet(options as WalletConnectWalletOptions);
-    this.kit = newKit(network.rpcUrl, wallet as ReadOnlyWallet);
+    this.kit = newKit(network.rpcUrl, wallet);
     this.version = version;
   }
 

--- a/packages/react-celo/src/constants.tsx
+++ b/packages/react-celo/src/constants.tsx
@@ -22,14 +22,14 @@ import {
   WALLETCONNECT,
 } from './walletIcons';
 
-export const localStorageKeys = {
-  lastUsedAddress: 'react-celo/last-used-address',
-  lastUsedNetwork: 'react-celo/last-used-network',
-  lastUsedWalletType: 'react-celo/last-used-wallet',
-  lastUsedWalletId: 'react-celo/last-used-wallet-id',
-  lastUsedWalletArguments: 'react-celo/last-used-wallet-arguments',
-  lastUsedFeeCurrency: 'react-celo/last-used-fee-currency',
-};
+export enum localStorageKeys {
+  lastUsedAddress = 'react-celo/last-used-address',
+  lastUsedNetwork = 'react-celo/last-used-network',
+  lastUsedWalletType = 'react-celo/last-used-wallet',
+  lastUsedWalletId = 'react-celo/last-used-wallet-id',
+  lastUsedWalletArguments = 'react-celo/last-used-wallet-arguments',
+  lastUsedFeeCurrency = 'react-celo/last-used-fee-currency',
+}
 
 export enum SupportedProviders {
   CeloExtensionWallet = 'Celo Extension Wallet',

--- a/packages/react-celo/src/react-celo-reducer.ts
+++ b/packages/react-celo/src/react-celo-reducer.ts
@@ -1,10 +1,14 @@
 import { CeloTokenContract } from '@celo/contractkit/lib/base';
 
 import { UnauthenticatedConnector } from './connectors';
-import { localStorageKeys } from './constants';
 import { Connector, Dapp, Maybe, Network, Theme } from './types';
-import { clearPreviousConfig } from './utils/helpers';
-import localStorage from './utils/localStorage';
+import {
+  clearPreviousConfig,
+  removeLastUsedAddress,
+  setLastUsedAddress,
+  setLastUsedFeeCurrency,
+  setLastUsedNetwork,
+} from './utils/localStorage';
 
 export function celoReactReducer(
   state: ReducerState,
@@ -22,9 +26,9 @@ export function celoReactReducer(
         return state;
       }
       if (action.payload) {
-        localStorage.setItem(localStorageKeys.lastUsedAddress, action.payload);
+        setLastUsedAddress(action.payload);
       } else {
-        localStorage.removeItem(localStorageKeys.lastUsedAddress);
+        removeLastUsedAddress();
       }
       return {
         ...state,
@@ -34,17 +38,14 @@ export function celoReactReducer(
       if (action.payload === state.network) {
         return state;
       }
-      localStorage.setItem(
-        localStorageKeys.lastUsedNetwork,
-        action.payload.name
-      );
+      setLastUsedNetwork(action.payload.name);
       return {
         ...state,
         network: action.payload,
       };
 
     case 'setConnector':
-      localStorage.removeItem(localStorageKeys.lastUsedAddress);
+      removeLastUsedAddress();
       return {
         ...state,
         connector: action.payload,
@@ -55,16 +56,13 @@ export function celoReactReducer(
       if (action.payload === state.feeCurrency) {
         return state;
       }
-      localStorage.setItem(
-        localStorageKeys.lastUsedFeeCurrency,
-        action.payload
-      );
+      setLastUsedFeeCurrency(action.payload);
       return { ...state, feeCurrency: action.payload };
     case 'initialisedConnector': {
       const newConnector = action.payload;
       const address = newConnector.kit.connection.defaultAccount ?? null;
       if (address) {
-        localStorage.setItem(localStorageKeys.lastUsedAddress, address);
+        setLastUsedAddress(address);
       }
       return {
         ...state,

--- a/packages/react-celo/src/react-celo-reducer.ts
+++ b/packages/react-celo/src/react-celo-reducer.ts
@@ -1,13 +1,12 @@
 import { CeloTokenContract } from '@celo/contractkit/lib/base';
 
 import { UnauthenticatedConnector } from './connectors';
+import { localStorageKeys as lsKeys } from './constants';
 import { Connector, Dapp, Maybe, Network, Theme } from './types';
 import {
   clearPreviousConfig,
   removeLastUsedAddress,
-  setLastUsedAddress,
-  setLastUsedFeeCurrency,
-  setLastUsedNetwork,
+  setTypedStorageKey,
 } from './utils/localStorage';
 
 export function celoReactReducer(
@@ -26,7 +25,7 @@ export function celoReactReducer(
         return state;
       }
       if (action.payload) {
-        setLastUsedAddress(action.payload);
+        setTypedStorageKey(lsKeys.lastUsedAddress, action.payload);
       } else {
         removeLastUsedAddress();
       }
@@ -38,7 +37,7 @@ export function celoReactReducer(
       if (action.payload === state.network) {
         return state;
       }
-      setLastUsedNetwork(action.payload.name);
+      setTypedStorageKey(lsKeys.lastUsedNetwork, action.payload.name);
       return {
         ...state,
         network: action.payload,
@@ -56,13 +55,13 @@ export function celoReactReducer(
       if (action.payload === state.feeCurrency) {
         return state;
       }
-      setLastUsedFeeCurrency(action.payload);
+      setTypedStorageKey(lsKeys.lastUsedFeeCurrency, action.payload);
       return { ...state, feeCurrency: action.payload };
     case 'initialisedConnector': {
       const newConnector = action.payload;
       const address = newConnector.kit.connection.defaultAccount ?? null;
       if (address) {
-        setLastUsedAddress(address);
+        setTypedStorageKey(lsKeys.lastUsedAddress, address);
       }
       return {
         ...state,

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -4,11 +4,7 @@ import { useCallback } from 'react';
 import { isMobile } from 'react-device-detect';
 
 import { CONNECTOR_TYPES } from './connectors';
-import {
-  localStorageKeys,
-  STATIC_NETWORK_WALLETS,
-  WalletTypes,
-} from './constants';
+import { STATIC_NETWORK_WALLETS, WalletTypes } from './constants';
 import {
   ContractCacheBuilder,
   useContractsCache,

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -17,6 +17,7 @@ import { Dispatcher } from './react-celo-provider';
 import defaultTheme from './theme/default';
 import { Connector, Network, Theme } from './types';
 import { RGBToHex } from './utils/helpers';
+import { getLastUsedWalletArgs } from './utils/localStorage';
 
 export function useCeloMethods(
   {
@@ -123,9 +124,7 @@ export function useCeloMethods(
       }
       if (network === newNetwork) return;
       if (connector.initialised) {
-        const connectorArgs = JSON.parse(
-          localStorage.getItem(localStorageKeys.lastUsedWalletArguments) || '[]'
-        ) as unknown[];
+        const connectorArgs = getLastUsedWalletArgs() || [];
         await connector.close();
         const ConnectorConstructor = CONNECTOR_TYPES[connector.type];
         const newConnector = new ConnectorConstructor(

--- a/packages/react-celo/src/utils/clearPreviousConfig.ts
+++ b/packages/react-celo/src/utils/clearPreviousConfig.ts
@@ -1,0 +1,9 @@
+import { localStorageKeys } from '../constants';
+
+export function clearPreviousConfig(): void {
+  Object.values(localStorageKeys).forEach((val) => {
+    if (val === localStorageKeys.lastUsedWalletId) return;
+    if (val === localStorageKeys.lastUsedWalletType) return;
+    localStorage.removeItem(val);
+  });
+}

--- a/packages/react-celo/src/utils/clearPreviousConfig.ts
+++ b/packages/react-celo/src/utils/clearPreviousConfig.ts
@@ -1,9 +1,0 @@
-import { localStorageKeys } from '../constants';
-
-export function clearPreviousConfig(): void {
-  Object.values(localStorageKeys).forEach((val) => {
-    if (val === localStorageKeys.lastUsedWalletId) return;
-    if (val === localStorageKeys.lastUsedWalletType) return;
-    localStorage.removeItem(val);
-  });
-}

--- a/packages/react-celo/src/utils/helpers.ts
+++ b/packages/react-celo/src/utils/helpers.ts
@@ -1,9 +1,16 @@
 import { CeloContract, CeloTokenContract } from '@celo/contractkit/lib/base';
 
 import { CONNECTOR_TYPES, UnauthenticatedConnector } from '../connectors';
-import { localStorageKeys, WalletTypes } from '../constants';
+import { WalletTypes } from '../constants';
 import { Connector, Maybe, Network } from '../types';
-import localStorage from './localStorage';
+import {
+  getLastUsedAddress,
+  getLastUsedFeeCurrency,
+  getLastUsedNetwork,
+  getLastUsedWalletArgs,
+  getLastUsedWalletType,
+  localStorageAvailable,
+} from './localStorage';
 
 export const loadPreviousConfig = (
   defaultNetworkProp: Network,
@@ -20,40 +27,22 @@ export const loadPreviousConfig = (
   let lastUsedWalletType: WalletTypes = WalletTypes.Unauthenticated;
   let lastUsedWalletArguments: unknown[] = [];
   let lastUsedFeeCurrency: CeloContract = defaultFeeCurrencyProp;
-  if (typeof localStorage !== 'undefined') {
-    const localLastUsedNetworkName = localStorage.getItem(
-      localStorageKeys.lastUsedNetwork
-    );
+  if (localStorageAvailable()) {
+    const localLastUsedNetworkName = getLastUsedNetwork();
     if (localLastUsedNetworkName) {
       lastUsedNetworkName = localLastUsedNetworkName;
     }
 
-    lastUsedAddress = localStorage.getItem(localStorageKeys.lastUsedAddress);
+    lastUsedAddress = getLastUsedAddress();
 
-    const localLastUsedWalletType = localStorage.getItem(
-      localStorageKeys.lastUsedWalletType
-    );
+    const localLastUsedWalletType = getLastUsedWalletType();
     if (localLastUsedWalletType && localLastUsedWalletType in WalletTypes) {
-      lastUsedWalletType = localLastUsedWalletType as WalletTypes;
+      lastUsedWalletType = localLastUsedWalletType;
     }
 
-    const localLastUsedWalletArguments = localStorage.getItem(
-      localStorageKeys.lastUsedWalletArguments
-    );
+    lastUsedWalletArguments = getLastUsedWalletArgs() || [];
 
-    if (localLastUsedWalletArguments) {
-      try {
-        lastUsedWalletArguments = JSON.parse(
-          localLastUsedWalletArguments
-        ) as unknown[];
-      } catch (e) {
-        lastUsedWalletArguments = [];
-      }
-    }
-
-    const localLastUsedFeeCurrency = localStorage.getItem(
-      localStorageKeys.lastUsedFeeCurrency
-    );
+    const localLastUsedFeeCurrency = getLastUsedFeeCurrency();
 
     if (isValidFeeCurrency(localLastUsedFeeCurrency)) {
       lastUsedFeeCurrency = localLastUsedFeeCurrency as CeloTokenContract;
@@ -88,14 +77,6 @@ export const loadPreviousConfig = (
     feeCurrency: lastUsedFeeCurrency,
   };
 };
-
-export function clearPreviousConfig(): void {
-  Object.values(localStorageKeys).forEach((val) => {
-    if (val === localStorageKeys.lastUsedWalletId) return;
-    if (val === localStorageKeys.lastUsedWalletType) return;
-    localStorage.removeItem(val);
-  });
-}
 
 export function isValidFeeCurrency(currency: Maybe<string>): boolean {
   switch (currency) {

--- a/packages/react-celo/src/utils/helpers.ts
+++ b/packages/react-celo/src/utils/helpers.ts
@@ -1,14 +1,11 @@
 import { CeloContract, CeloTokenContract } from '@celo/contractkit/lib/base';
 
 import { CONNECTOR_TYPES, UnauthenticatedConnector } from '../connectors';
-import { WalletTypes } from '../constants';
+import { localStorageKeys, WalletTypes } from '../constants';
 import { Connector, Maybe, Network } from '../types';
 import {
-  getLastUsedAddress,
-  getLastUsedFeeCurrency,
-  getLastUsedNetwork,
   getLastUsedWalletArgs,
-  getLastUsedWalletType,
+  getTypedStorageKey,
   localStorageAvailable,
 } from './localStorage';
 
@@ -28,21 +25,27 @@ export const loadPreviousConfig = (
   let lastUsedWalletArguments: unknown[] = [];
   let lastUsedFeeCurrency: CeloContract = defaultFeeCurrencyProp;
   if (localStorageAvailable()) {
-    const localLastUsedNetworkName = getLastUsedNetwork();
+    const localLastUsedNetworkName = getTypedStorageKey(
+      localStorageKeys.lastUsedNetwork
+    );
     if (localLastUsedNetworkName) {
       lastUsedNetworkName = localLastUsedNetworkName;
     }
 
-    lastUsedAddress = getLastUsedAddress();
+    lastUsedAddress = getTypedStorageKey(localStorageKeys.lastUsedAddress);
 
-    const localLastUsedWalletType = getLastUsedWalletType();
+    const localLastUsedWalletType = getTypedStorageKey(
+      localStorageKeys.lastUsedWalletType
+    );
     if (localLastUsedWalletType && localLastUsedWalletType in WalletTypes) {
       lastUsedWalletType = localLastUsedWalletType;
     }
 
     lastUsedWalletArguments = getLastUsedWalletArgs() || [];
 
-    const localLastUsedFeeCurrency = getLastUsedFeeCurrency();
+    const localLastUsedFeeCurrency = getTypedStorageKey(
+      localStorageKeys.lastUsedFeeCurrency
+    );
 
     if (isValidFeeCurrency(localLastUsedFeeCurrency)) {
       lastUsedFeeCurrency = localLastUsedFeeCurrency as CeloTokenContract;

--- a/packages/react-celo/src/utils/localStorage.test.ts
+++ b/packages/react-celo/src/utils/localStorage.test.ts
@@ -1,3 +1,5 @@
+import { CeloContract } from '@celo/contractkit';
+
 import { localStorageKeys, WalletTypes } from '../constants';
 import {
   forgetConnection,
@@ -18,47 +20,67 @@ describe('TypedLocalStorage', () => {
         );
       });
     });
+    describe(localStorageKeys.lastUsedWalletType, () => {
+      it('sets Last used Wallet', () => {
+        setTypedStorageKey(
+          localStorageKeys.lastUsedWalletType,
+          WalletTypes.MetaMask
+        );
+        expect(getTypedStorageKey(localStorageKeys.lastUsedWalletType)).toEqual(
+          WalletTypes.MetaMask
+        );
+      });
+    });
+    describe(localStorageKeys.lastUsedFeeCurrency, () => {
+      it('sets Last used Wallet', () => {
+        setTypedStorageKey(
+          localStorageKeys.lastUsedFeeCurrency,
+          CeloContract.StableTokenBRL
+        );
+        expect(
+          getTypedStorageKey(localStorageKeys.lastUsedFeeCurrency)
+        ).toEqual(CeloContract.StableTokenBRL);
+      });
+    });
   });
   describe('get/setLastUsedWalletArgs', () => {
-    describe('', () => {
-      it('accepts string', () => {
-        const args = ['0x123456789'] as [string];
-        setLastUsedWalletArgs(args);
-        expect(getLastUsedWalletArgs()).toMatchObject(args);
-      });
-      it('accepts number', () => {
-        const args = [1] as [1];
-        setLastUsedWalletArgs(args);
-        expect(getLastUsedWalletArgs()).toMatchObject(args);
-      });
-      it('accepts object arg', () => {
-        const args = [
-          {
-            init: {
+    it('accepts string', () => {
+      const args = ['0x123456789'] as [string];
+      setLastUsedWalletArgs(args);
+      expect(getLastUsedWalletArgs()).toMatchObject(args);
+    });
+    it('accepts number', () => {
+      const args = [1] as [1];
+      setLastUsedWalletArgs(args);
+      expect(getLastUsedWalletArgs()).toMatchObject(args);
+    });
+    it('accepts object arg', () => {
+      const args = [
+        {
+          init: {
+            bridge: 'bridge.react-celo.nom',
+            uri: 'uri.react-celo.nom',
+            storageId: '212',
+            signingMethods: ['eth_sign'],
+            session: {
+              connected: false,
+              accounts: ['0x0123123'],
+              chainId: 1,
               bridge: 'bridge.react-celo.nom',
-              uri: 'uri.react-celo.nom',
-              storageId: '212',
-              signingMethods: ['eth_sign'],
-              session: {
-                connected: false,
-                accounts: ['0x0123123'],
-                chainId: 1,
-                bridge: 'bridge.react-celo.nom',
-                key: 'key',
-                clientId: '1123123',
-                clientMeta: null,
-                peerId: 'ksjhf1333',
-                peerMeta: null,
-                handshakeId: 99,
-                handshakeTopic: 'opti8',
-              },
+              key: 'key',
+              clientId: '1123123',
+              clientMeta: null,
+              peerId: 'ksjhf1333',
+              peerMeta: null,
+              handshakeId: 99,
+              handshakeTopic: 'opti8',
             },
-            connect: { chainId: 44 },
           },
-        ];
-        setLastUsedWalletArgs(args as WalletArgs);
-        expect(getLastUsedWalletArgs()).toMatchObject(args);
-      });
+          connect: { chainId: 44 },
+        },
+      ];
+      setLastUsedWalletArgs(args as WalletArgs);
+      expect(getLastUsedWalletArgs()).toMatchObject(args);
     });
   });
 

--- a/packages/react-celo/src/utils/localStorage.test.ts
+++ b/packages/react-celo/src/utils/localStorage.test.ts
@@ -1,0 +1,98 @@
+import { localStorageKeys, WalletTypes } from '../constants';
+import {
+  forgetConnection,
+  getLastUsedWalletArgs,
+  getTypedStorageKey,
+  setLastUsedWalletArgs,
+  setTypedStorageKey,
+  WalletArgs,
+} from './localStorage';
+
+describe('TypedLocalStorage', () => {
+  describe('get/setTypedStorageKey', () => {
+    describe(localStorageKeys.lastUsedAddress, () => {
+      it('sets Address', () => {
+        setTypedStorageKey(localStorageKeys.lastUsedAddress, 'address');
+        expect(getTypedStorageKey(localStorageKeys.lastUsedAddress)).toEqual(
+          'address'
+        );
+      });
+    });
+  });
+  describe('get/setLastUsedWalletArgs', () => {
+    describe('', () => {
+      it('accepts string', () => {
+        const args = ['0x123456789'] as [string];
+        setLastUsedWalletArgs(args);
+        expect(getLastUsedWalletArgs()).toMatchObject(args);
+      });
+      it('accepts number', () => {
+        const args = [1] as [1];
+        setLastUsedWalletArgs(args);
+        expect(getLastUsedWalletArgs()).toMatchObject(args);
+      });
+      it('accepts object arg', () => {
+        const args = [
+          {
+            init: {
+              bridge: 'bridge.react-celo.nom',
+              uri: 'uri.react-celo.nom',
+              storageId: '212',
+              signingMethods: ['eth_sign'],
+              session: {
+                connected: false,
+                accounts: ['0x0123123'],
+                chainId: 1,
+                bridge: 'bridge.react-celo.nom',
+                key: 'key',
+                clientId: '1123123',
+                clientMeta: null,
+                peerId: 'ksjhf1333',
+                peerMeta: null,
+                handshakeId: 99,
+                handshakeTopic: 'opti8',
+              },
+            },
+            connect: { chainId: 44 },
+          },
+        ];
+        setLastUsedWalletArgs(args as WalletArgs);
+        expect(getLastUsedWalletArgs()).toMatchObject(args);
+      });
+    });
+  });
+
+  describe(forgetConnection, () => {
+    beforeEach(() => {
+      setLastUsedWalletArgs([1]);
+      setTypedStorageKey(localStorageKeys.lastUsedNetwork, 'Alfajores');
+      setTypedStorageKey(
+        localStorageKeys.lastUsedWalletType,
+        WalletTypes.Injected
+      );
+    });
+    it('resets last Network', () => {
+      expect(getTypedStorageKey(localStorageKeys.lastUsedNetwork)).toEqual(
+        'Alfajores'
+      );
+      forgetConnection();
+      expect(getTypedStorageKey(localStorageKeys.lastUsedNetwork)).toEqual(
+        null
+      );
+    });
+    it('resets last used type', () => {
+      expect(getTypedStorageKey(localStorageKeys.lastUsedWalletType)).toEqual(
+        WalletTypes.Injected
+      );
+      forgetConnection();
+      expect(getTypedStorageKey(localStorageKeys.lastUsedWalletType)).toEqual(
+        null
+      );
+    });
+    it('resets last used arguments', () => {
+      expect(getLastUsedWalletArgs()).toEqual([1]);
+      forgetConnection();
+      expect(getLastUsedWalletArgs()).toBe(null);
+    });
+  });
+});

--- a/packages/react-celo/src/utils/localStorage.ts
+++ b/packages/react-celo/src/utils/localStorage.ts
@@ -50,52 +50,27 @@ const localStorage =
     ? new MockedLocalStorage()
     : window.localStorage;
 
-export function getLastUsedAddress(): string | null {
-  return localStorage.getItem(localStorageKeys.lastUsedAddress);
+type ParamType<T> = T extends localStorageKeys.lastUsedFeeCurrency
+  ? CeloTokenContract
+  : T extends localStorageKeys.lastUsedWalletType
+  ? WalletTypes
+  : string;
+
+export function getTypedStorageKey<T extends localStorageKeys>(
+  key: T
+): ParamType<T> | null {
+  return localStorage.getItem(key) as ParamType<T>;
 }
 
-export function setLastUsedAddress(address: string) {
-  localStorage.setItem(localStorageKeys.lastUsedAddress, address);
+export function setTypedStorageKey<
+  T extends localStorageKeys,
+  V extends ParamType<T>
+>(key: T, value: V): void {
+  localStorage.setItem(key, value);
 }
 
 export function removeLastUsedAddress() {
   localStorage.removeItem(localStorageKeys.lastUsedAddress);
-}
-
-export function getLastUsedNetwork(): string | null {
-  return localStorage.getItem(localStorageKeys.lastUsedNetwork);
-}
-
-export function setLastUsedNetwork(networkName: string) {
-  localStorage.setItem(localStorageKeys.lastUsedNetwork, networkName);
-}
-
-export function getLastUsedFeeCurrency(): CeloTokenContract | null {
-  return localStorage.getItem(
-    localStorageKeys.lastUsedFeeCurrency
-  ) as CeloTokenContract;
-}
-
-export function setLastUsedFeeCurrency(feeCurrency: CeloTokenContract) {
-  localStorage.setItem(localStorageKeys.lastUsedFeeCurrency, feeCurrency);
-}
-
-export function setLastUsedWalletId(id: string) {
-  localStorage.setItem(localStorageKeys.lastUsedWalletId, id);
-}
-
-export function getLastUsedWalletId() {
-  return localStorage.getItem(localStorageKeys.lastUsedWalletId);
-}
-
-export function getLastUsedWalletType(): WalletTypes | null {
-  return localStorage.getItem(
-    localStorageKeys.lastUsedWalletType
-  ) as WalletTypes;
-}
-
-export function setLastUsedWalletType(type: WalletTypes) {
-  localStorage.setItem(localStorageKeys.lastUsedWalletType, type);
 }
 
 export type WalletArgs =
@@ -116,7 +91,7 @@ export function getLastUsedWalletArgs(): WalletArgs | null {
   return null;
 }
 
-export function setLastUsedWalletArgs(params: WalletArgs) {
+export function setLastUsedWalletArgs<T>(params: WalletArgs) {
   const args = JSON.stringify(params);
   localStorage.setItem(localStorageKeys.lastUsedWalletArguments, args);
 }

--- a/packages/react-celo/src/utils/localStorage.ts
+++ b/packages/react-celo/src/utils/localStorage.ts
@@ -91,7 +91,7 @@ export function getLastUsedWalletArgs(): WalletArgs | null {
   return null;
 }
 
-export function setLastUsedWalletArgs<T>(params: WalletArgs) {
+export function setLastUsedWalletArgs(params: WalletArgs) {
   const args = JSON.stringify(params);
   localStorage.setItem(localStorageKeys.lastUsedWalletArguments, args);
 }

--- a/packages/react-celo/src/utils/localStorage.ts
+++ b/packages/react-celo/src/utils/localStorage.ts
@@ -1,3 +1,8 @@
+import { CeloTokenContract } from '@celo/contractkit';
+import { WalletConnectWalletOptions } from '@celo/wallet-walletconnect-v1';
+
+import { localStorageKeys, WalletTypes } from '../constants';
+
 class MockedLocalStorage implements Storage {
   private storage = new Map<string, string>();
 
@@ -45,4 +50,93 @@ const localStorage =
     ? new MockedLocalStorage()
     : window.localStorage;
 
-export default localStorage;
+export function getLastUsedAddress(): string | null {
+  return localStorage.getItem(localStorageKeys.lastUsedAddress);
+}
+
+export function setLastUsedAddress(address: string) {
+  localStorage.setItem(localStorageKeys.lastUsedAddress, address);
+}
+
+export function removeLastUsedAddress() {
+  localStorage.removeItem(localStorageKeys.lastUsedAddress);
+}
+
+export function getLastUsedNetwork(): string | null {
+  return localStorage.getItem(localStorageKeys.lastUsedNetwork);
+}
+
+export function setLastUsedNetwork(networkName: string) {
+  localStorage.setItem(localStorageKeys.lastUsedNetwork, networkName);
+}
+
+export function getLastUsedFeeCurrency(): CeloTokenContract | null {
+  return localStorage.getItem(
+    localStorageKeys.lastUsedFeeCurrency
+  ) as CeloTokenContract;
+}
+
+export function setLastUsedFeeCurrency(feeCurrency: CeloTokenContract) {
+  localStorage.setItem(localStorageKeys.lastUsedFeeCurrency, feeCurrency);
+}
+
+export function setLastUsedWalletId(id: string) {
+  localStorage.setItem(localStorageKeys.lastUsedWalletId, id);
+}
+
+export function getLastUsedWalletId() {
+  return localStorage.getItem(localStorageKeys.lastUsedWalletId);
+}
+
+export function getLastUsedWalletType(): WalletTypes | null {
+  return localStorage.getItem(
+    localStorageKeys.lastUsedWalletType
+  ) as WalletTypes;
+}
+
+export function setLastUsedWalletType(type: WalletTypes) {
+  localStorage.setItem(localStorageKeys.lastUsedWalletType, type);
+}
+
+export type WalletArgs =
+  | [string]
+  | [CeloTokenContract]
+  | [WalletConnectWalletOptions]
+  | [number]
+  | [];
+
+export function getLastUsedWalletArgs(): WalletArgs | null {
+  const args = localStorage.getItem(localStorageKeys.lastUsedWalletArguments);
+  if (args && args.length) {
+    const parsed = JSON.parse(args) as WalletArgs;
+
+    return parsed;
+  }
+
+  return null;
+}
+
+export function setLastUsedWalletArgs(params: WalletArgs) {
+  const args = JSON.stringify(params);
+  localStorage.setItem(localStorageKeys.lastUsedWalletArguments, args);
+}
+
+export function forgetConnection() {
+  [
+    localStorageKeys.lastUsedWalletType,
+    localStorageKeys.lastUsedWalletArguments,
+    localStorageKeys.lastUsedNetwork,
+  ].forEach((key) => localStorage.removeItem(key));
+}
+
+export function clearPreviousConfig(): void {
+  Object.values(localStorageKeys).forEach((val) => {
+    if (val === localStorageKeys.lastUsedWalletId) return;
+    if (val === localStorageKeys.lastUsedWalletType) return;
+    localStorage.removeItem(val);
+  });
+}
+
+export function localStorageAvailable() {
+  return typeof localStorage !== 'undefined';
+}

--- a/packages/react-celo/src/utils/useProviders.ts
+++ b/packages/react-celo/src/utils/useProviders.ts
@@ -1,14 +1,9 @@
 import { useMemo } from 'react';
 import { isMobile } from 'react-device-detect';
 
-import {
-  localStorageKeys,
-  Priorities,
-  PROVIDERS,
-  WalletTypes,
-} from '../constants';
+import { Priorities, PROVIDERS, WalletTypes } from '../constants';
 import { Maybe, Provider, WalletConnectProvider, WalletEntry } from '../types';
-import localStorage from './localStorage';
+import { getLastUsedWalletId, getLastUsedWalletType } from './localStorage';
 import { defaultProviderSort } from './sort';
 
 export function walletToProvider(wallet: WalletEntry): WalletConnectProvider {
@@ -26,8 +21,8 @@ export function walletToProvider(wallet: WalletEntry): WalletConnectProvider {
 }
 
 export function getRecent(): Maybe<Provider> {
-  const type = localStorage.getItem(localStorageKeys.lastUsedWalletType);
-  const id = localStorage.getItem(localStorageKeys.lastUsedWalletId);
+  const type = getLastUsedWalletType();
+  const id = getLastUsedWalletId();
   let provider;
 
   if (id && WalletTypes.WalletConnect === type) {

--- a/packages/react-celo/src/utils/useProviders.ts
+++ b/packages/react-celo/src/utils/useProviders.ts
@@ -1,9 +1,14 @@
 import { useMemo } from 'react';
 import { isMobile } from 'react-device-detect';
 
-import { Priorities, PROVIDERS, WalletTypes } from '../constants';
+import {
+  localStorageKeys,
+  Priorities,
+  PROVIDERS,
+  WalletTypes,
+} from '../constants';
 import { Maybe, Provider, WalletConnectProvider, WalletEntry } from '../types';
-import { getLastUsedWalletId, getLastUsedWalletType } from './localStorage';
+import { getTypedStorageKey } from './localStorage';
 import { defaultProviderSort } from './sort';
 
 export function walletToProvider(wallet: WalletEntry): WalletConnectProvider {
@@ -21,8 +26,8 @@ export function walletToProvider(wallet: WalletEntry): WalletConnectProvider {
 }
 
 export function getRecent(): Maybe<Provider> {
-  const type = getLastUsedWalletType();
-  const id = getLastUsedWalletId();
+  const type = getTypedStorageKey(localStorageKeys.lastUsedWalletType);
+  const id = getTypedStorageKey(localStorageKeys.lastUsedWalletId);
   let provider;
 
   if (id && WalletTypes.WalletConnect === type) {

--- a/packages/walletconnect-v1/src/wc-wallet.ts
+++ b/packages/walletconnect-v1/src/wc-wallet.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../node_modules/@walletconnect/types-v1/index.d.ts' />
 
 import { sleep } from '@celo/base';
-import { CeloTx, EncodedTransaction } from '@celo/connect';
+import { CeloTx, EncodedTransaction } from '@celo/connect/lib/types';
 import { RemoteWallet } from '@celo/wallet-remote';
 import WalletConnect from '@walletconnect/client-v1';
 import {


### PR DESCRIPTION
Use specific getter and setter functions for accessing local storage rather than calling directly. this allows for us to type the input and output and do serialization in one spot. 

Fixes #252 