### PR TITLE
Add Cypress UI Testing

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v4
         env:
-          CYPRESS_deployedURL: https://react-celo-${{github.head_ref}}-c-labs.vercel.app
+          CYPRESS_deployedURL: https://react-celo-git-${{github.GITHUB_REF_NAME}}-c-labs.vercel.app/
         with:
           browser: chrome
           project: './packages/example'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,17 @@
+name: UI Tests on Chrome
+on: [push]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Install NPM dependencies, cache them correctly
+      # and run all Cypress tests
+      - name: Cypress run
+        uses: cypress-io/github-action@v4
+        env:
+          BASE_CYPRESS_URL: https://react-celo-git-${{github.head_ref}}-c-labs.vercel.app
+        with:
+          browser: chrome
+          project: './packages/example'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,7 +11,8 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v4
         env:
-          BASE_CYPRESS_URL: https://react-celo-git-${{github.head_ref}}-c-labs.vercel.app
+          BASE_CYPRESS_URL: https://react-celo-${{github.head_ref}}-c-labs.vercel.app
+
         with:
           browser: chrome
           project: './packages/example'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v4
         env:
-          CYPRESS_deployedURL: https://react-celo-git-${{github.ref_name}}--${{GITHUB_REF_NAME}}-c-labs.vercel.app
+          CYPRESS_deployedURL: https://react-celo-git-${{github.ref_name}}-c-labs.vercel.app
         with:
           browser: chrome
           project: './packages/example'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,8 +11,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v4
         env:
-          CYPRESS_BASE_URL: https://react-celo-${{github.head_ref}}-c-labs.vercel.app
-
+          CYPRESS_deployedURL: https://react-celo-${{github.head_ref}}-c-labs.vercel.app
         with:
           browser: chrome
           project: './packages/example'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v4
         env:
-          CYPRESS_deployedURL: https://react-celo-git-${{github.GITHUB_REF_NAME}}-c-labs.vercel.app/
+          CYPRESS_deployedURL: https://react-celo-git-${{github.ref_name}}--${{GITHUB_REF_NAME}}-c-labs.vercel.app
         with:
           browser: chrome
           project: './packages/example'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v4
         env:
-          CYPRESS_deployedURL: https://react-celo-git-${{github.ref_name}}-c-labs.vercel.app
+          CYPRESS_deployedURL: react-celo-git-${{github.ref_name}}-c-labs.vercel.app
         with:
           browser: chrome
           project: './packages/example'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v4
         env:
-          BASE_CYPRESS_URL: https://react-celo-${{github.head_ref}}-c-labs.vercel.app
+          CYPRESS_BASE_URL: https://react-celo-${{github.head_ref}}-c-labs.vercel.app
 
         with:
           browser: chrome

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ dist
 .Trashes
 ehthumbs.db
 Thumbs.db
+packages/example/cypress/videos

--- a/packages/example/cypress.config.ts
+++ b/packages/example/cypress.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     },
   },
   env: {
-    BASE_URL: '1',
+    deployedURL: '1',
   },
 });

--- a/packages/example/cypress.config.ts
+++ b/packages/example/cypress.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    experimentalSessionAndOrigin: true,
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+});

--- a/packages/example/cypress.config.ts
+++ b/packages/example/cypress.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     },
   },
   env: {
-    deployedURL: '1',
+    deployedURL: 'http://localhost:3000',
   },
 });

--- a/packages/example/cypress.config.ts
+++ b/packages/example/cypress.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
       // implement node event listeners here
     },
   },
+  env: {
+    BASE_URL: '1',
+  },
 });

--- a/packages/example/cypress.config.ts
+++ b/packages/example/cypress.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     },
   },
   env: {
-    deployedURL: 'http://localhost:3000',
+    deployedURL: 'localhost:3000',
   },
 });

--- a/packages/example/cypress.d.ts
+++ b/packages/example/cypress.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="cypress" />

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -1,15 +1,17 @@
 /// <reference types="cypress" />
 /// <reference types="@testing-library/cypress" />
 
-const BASE_URL = process.env.BASE_CYPRESS_URL || 'http://localhost:3000';
-console.info('BASE', BASE_URL);
 function openModal() {
   cy.get('button[aria-label="Run Connect wallet to mainnet"]').click();
 }
 
 context('Wallet Test Plan', () => {
   beforeEach(() => {
-    cy.visit(`${BASE_URL}/wallet-test-plan`);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const baseUrl: string =
+      Cypress.env('CYPRESS_BASE_URL') || 'http://localhost:3000';
+    console.info('BASE', baseUrl);
+    cy.visit(`${baseUrl}/wallet-test-plan`);
   });
 
   it('searches', () => {

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -9,8 +9,8 @@ context('Wallet Test Plan', () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const baseUrl: string = Cypress.env('deployedURL');
-    console.info('deployedURL', baseUrl);
-    cy.visit(`${baseUrl}/wallet-test-plan`);
+    const fixedUrl = baseUrl.replace('/', '-');
+    cy.visit(`${fixedUrl}/wallet-test-plan`);
   });
 
   it('searches', () => {

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -9,8 +9,8 @@ context('Wallet Test Plan', () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const baseUrl: string =
-      Cypress.env('CYPRESS_BASE_URL') || 'http://localhost:3000';
-    console.info('BASE', baseUrl);
+      Cypress.env('deployedURL') || 'http://localhost:3000';
+    console.info('deployedURL', baseUrl);
     cy.visit(`${baseUrl}/wallet-test-plan`);
   });
 

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -27,19 +27,18 @@ context('Wallet Test Plan', () => {
     cy.get('input[role="search"]').clear();
   });
 
-  it('Connects with wallet connect', () => {
+  it('Connects with Private Key', () => {
     openModal();
-    cy.findByText('Celo Wallet').click();
+    cy.findByText('Private key').click();
 
-    // cy.get('button[aria-label="Connect with Celo Wallet Web"]').click();
+    cy.get('textarea').type(
+      'e2d7138baa3a5600ac37984e40981591d7cf857bcadd7dc6f7d14023a17b0787'
+    );
+    cy.findByText('Submit').click();
 
-    cy.origin('celowallet.app', () => {
-      cy.visit('https://celowallet.app');
-      cy.get('button')
-        .should('contain.text', 'Create New Account')
-        .first()
-        .click();
-    });
+    cy.findByText('Connected to').should('exist');
+
+    cy.findAllByText('success').should('have.length', 1);
   });
 });
 

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -10,7 +10,7 @@ context('Wallet Test Plan', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const baseUrl: string = Cypress.env('deployedURL');
     const fixedUrl = baseUrl.replace('/', '-');
-    cy.visit(`${fixedUrl}/wallet-test-plan`);
+    cy.visit(`http://${fixedUrl}/wallet-test-plan`);
   });
 
   it('searches', () => {

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -1,8 +1,7 @@
 /// <reference types="cypress" />
 /// <reference types="@testing-library/cypress" />
 
-const BASE_URL = 'http://localhost:3000';
-
+const BASE_URL = process.env.BASE_CYPRESS_URL || 'http://localhost:3000';
 function openModal() {
   cy.get('button[aria-label="Run Connect wallet to mainnet"]').click();
 }

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -2,6 +2,7 @@
 /// <reference types="@testing-library/cypress" />
 
 const BASE_URL = process.env.BASE_CYPRESS_URL || 'http://localhost:3000';
+console.info('BASE', BASE_URL);
 function openModal() {
   cy.get('button[aria-label="Run Connect wallet to mainnet"]').click();
 }

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -8,8 +8,7 @@ function openModal() {
 context('Wallet Test Plan', () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const baseUrl: string =
-      Cypress.env('deployedURL') || 'http://localhost:3000';
+    const baseUrl: string = Cypress.env('deployedURL');
     console.info('deployedURL', baseUrl);
     cy.visit(`${baseUrl}/wallet-test-plan`);
   });

--- a/packages/example/cypress/e2e/wallet-test-plan.cy.ts
+++ b/packages/example/cypress/e2e/wallet-test-plan.cy.ts
@@ -1,0 +1,46 @@
+/// <reference types="cypress" />
+/// <reference types="@testing-library/cypress" />
+
+const BASE_URL = 'http://localhost:3000';
+
+function openModal() {
+  cy.get('button[aria-label="Run Connect wallet to mainnet"]').click();
+}
+
+context('Wallet Test Plan', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_URL}/wallet-test-plan`);
+  });
+
+  it('searches', () => {
+    openModal();
+    cy.findByText('Valora').should('exist');
+    cy.findByText('WalletConnect').should('exist');
+    cy.findByText('Celo Wallet').should('exist');
+
+    cy.get('input[role="search"]').type('Celo');
+
+    cy.findByText('Celo Wallet').should('exist');
+    cy.findByText('Valora').should('not.exist');
+    cy.findByText('WalletConnect').should('not.exist');
+
+    cy.get('input[role="search"]').clear();
+  });
+
+  it('Connects with wallet connect', () => {
+    openModal();
+    cy.findByText('Celo Wallet').click();
+
+    // cy.get('button[aria-label="Connect with Celo Wallet Web"]').click();
+
+    cy.origin('celowallet.app', () => {
+      cy.visit('https://celowallet.app');
+      cy.get('button')
+        .should('contain.text', 'Create New Account')
+        .first()
+        .click();
+    });
+  });
+});
+
+export {};

--- a/packages/example/cypress/fixtures/example.json
+++ b/packages/example/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/packages/example/cypress/support/commands.ts
+++ b/packages/example/cypress/support/commands.ts
@@ -1,0 +1,39 @@
+/// <reference types="cypress" />
+
+import '@testing-library/cypress/add-commands';
+// ***********************************************
+// This example commands.ts shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }

--- a/packages/example/cypress/support/e2e.ts
+++ b/packages/example/cypress/support/e2e.ts
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/packages/example/jest-setup.ts
+++ b/packages/example/jest-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/example/jest.config.js
+++ b/packages/example/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   ...base,
   displayName: pkg.name,
   roots: ['<rootDir>'],
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
 };

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -10,7 +10,9 @@
     "lint:fix": "eslint . --fix",
     "start": "next start",
     "export": "next export",
-    "test": "jest"
+    "test": "jest",
+    "test:ui": "cypress open",
+    "test:ci": "cypress run"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/example/tsconfig.cypress.json
+++ b/packages/example/tsconfig.cypress.json
@@ -5,9 +5,15 @@
     "module": "esnext",
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "types": ["cypress", "node"],
     "sourceMap": true,
     "incremental": true
   },
-  "include": ["next-env.d.ts", "./jest-setup.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "./cypres/**/*.cy.ts"]
+  "include": [
+    "next-env.d.ts",
+    "@testing-library/jest-dom/extend-expect",
+    "./cypress.d.ts",
+    "**/*.cy.ts"
+  ],
+  "exclude": ["node_modules"]
 }

--- a/packages/example/tsconfig.json
+++ b/packages/example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.spec.json",
-  "exclude": ["**/*.test.ts"],
+  "exclude": ["**/*.test.tsx", "**/*.cy.ts"],
   "compilerOptions": {
     "jsx": "preserve"
   }

--- a/packages/react-celo/src/components/tray.tsx
+++ b/packages/react-celo/src/components/tray.tsx
@@ -133,6 +133,8 @@ export default function Tray({
         {onSearch && (
           <div className={styles.inputContainer}>
             <input
+              aria-label="Search by wallet name"
+              role="search"
               className={styles.input}
               style={{
                 background: theme.background,

--- a/packages/react-celo/src/screens/wallet-connect.tsx
+++ b/packages/react-celo/src/screens/wallet-connect.tsx
@@ -119,6 +119,7 @@ export const WalletConnect = ({ onSubmit, provider }: Props) => {
           <div className={styles.desktopContainer}>
             {(provider.supportedPlatforms || []).map((platform) => (
               <button
+                aria-label={`Connect with ${provider.name} ${platform}`}
                 onClick={() => onClickPlatform(platform)}
                 className={styles.desktopButton}
                 key={platform}

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,9 +447,9 @@
     yargs "^17.4.1"
 
 "@coinbase/wallet-sdk@^3.2.0":
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.5.0.tgz#a50cbe5779972f5471b20cbed200d3aae80b8d4c"
-  integrity sha512-xdYMpz98gNwhOnSCh7Rm+qziI/K7LnPJnqHI93sZIRiRGtRTtDihcxjVxV2s1rj9NsYjC5jcKiOEgm8VqIK8Tg==
+  version "3.4.2"
+  resolved "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.4.2.tgz#e4130511142556f8a09e75d1f52f43aba6bff092"
+  integrity sha512-AALPbVciVco9/7NgT2MKrmrMduN2Cd7t+QWmmO6WU72U/OUHXshIAZAJxMC0j7+7N3xA7x9SEbJ7+O5bHS33Ug==
   dependencies:
     "@metamask/safe-event-emitter" "2.0.0"
     "@solana/web3.js" "1.52.0"
@@ -1311,6 +1311,17 @@
     pirates "^4.0.4"
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
+
+"@jest/types@^27.2.5":
+  version "27.5.1"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz#3c79ec4a8ba61c170bf937bcf9e98a9df175ec80"
+  integrity sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
 
 "@jest/types@^28.1.3":
   version "28.1.3"
@@ -2550,9 +2561,9 @@
     defer-to-connect "^2.0.1"
 
 "@testing-library/dom@^8.5.0":
-  version "8.17.1"
-  resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-8.17.1.tgz#2d7af4ff6dad8d837630fecd08835aee08320ad7"
-  integrity sha512-KnH2MnJUzmFNPW6RIKfd+zf2Wue8mEKX0M3cpX6aKl5ZXrJM1/c/Pc8c2xDNYQCnJO48Sm5ITbMXgqTr3h4jxQ==
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
+  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
@@ -2826,10 +2837,15 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
-"@types/node@^12.12.54", "@types/node@^12.12.6":
+"@types/node@^12.12.54":
   version "12.20.55"
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
+"@types/node@^12.12.6":
+  version "12.20.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.23.tgz#d0d5885bb885ee9b1ed114a04ea586540a1b2e2a"
+  integrity sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw==
 
 "@types/node@^16.3.0":
   version "16.11.49"
@@ -2975,6 +2991,13 @@
   version "21.0.0"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
+
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.11"
@@ -3760,7 +3783,7 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1:
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
-body-parser@1.20.0, body-parser@^1.16.0:
+body-parser@1.20.0:
   version "1.20.0"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
   integrity sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==
@@ -3777,6 +3800,22 @@ body-parser@1.20.0, body-parser@^1.16.0:
     raw-body "2.5.1"
     type-is "~1.6.18"
     unpipe "1.0.0"
+
+body-parser@^1.16.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+  integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
+  dependencies:
+    bytes "3.1.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.7.0"
+    raw-body "2.4.0"
+    type-is "~1.6.17"
 
 borsh@^0.7.0:
   version "0.7.0"
@@ -6859,7 +6898,21 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.5.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
+is-core-module@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
+  integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
   version "2.10.0"
   resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
   integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
@@ -7214,7 +7267,7 @@ jest-circus@^28.1.3:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-cli@^28.1.3:
+jest-cli@^28.1.0:
   version "28.1.3"
   resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-28.1.3.tgz#558b33c577d06de55087b8448d373b9f654e46b2"
   integrity sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==
@@ -9395,7 +9448,17 @@ prettier@^2.5.1:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
-pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.5.1:
+pretty-format@^27.0.0:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.3.1.tgz#7e9486365ccdd4a502061fa761d3ab9ca1b78df5"
+  integrity sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.2, pretty-format@^27.5.1:
   version "27.5.1"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==


### PR DESCRIPTION
## Why Cypress
Unlike unit tests run by jest Cypress opens a browser and you can visually follow along. This makes writing tests much easier  as you can see exactly what is happening. 

## Does this replace jest 

No Jest still great for unit testing and other tests. Cypress is great for tests of user does X screen should show Y. 

## How to use 

in example app 

`yarn test:ui` brings up interactive app for visual testing

`yarn test:ci` runs tests headless (good for ci)` 


## Demo  


https://user-images.githubusercontent.com/3814795/172925004-2c224e81-c059-4f51-a5e2-ac44fa7a9bba.mov

