### PR TITLE
fixes #203 deprecated network prop

### DIFF
--- a/packages/react-celo/src/react-celo-provider.tsx
+++ b/packages/react-celo/src/react-celo-provider.tsx
@@ -185,9 +185,9 @@ function getInitialNetwork(
   defaultNetwork?: string,
   passedNetwork?: Network // TODO:#246 remove when network prop is removed
 ) {
-  if (passedNetwork) {
+  if (process.env.NODE_ENV !== 'production' && passedNetwork) {
     console.warn(
-      'network prop on CeloProvider has been deprecated, use `defaultNetwork`'
+      '[react-celo] The `network` prop on CeloProvider has been deprecated, use `defaultNetwork`'
     );
   }
   const network = networks.find((net) => {


### PR DESCRIPTION
add defaultNetworkProp

allow both for now. and favor network so that this is a nonbreaking change

unless you count that this fixes passing in a unfindable network now throws an error instead of silently defaulting to main-net