### PR TITLE
When Modal is Open Dont Allow Background to scroll 

### DIFF
--- a/packages/react-celo/src/modals/action.tsx
+++ b/packages/react-celo/src/modals/action.tsx
@@ -7,6 +7,7 @@ import useTheme from '../hooks/use-theme';
 import { Theme } from '../types';
 import { useCeloInternal } from '../use-celo';
 import { hexToRGB } from '../utils/colors';
+import { useFixedBody } from '../utils/helpers';
 import cls from '../utils/tailwind';
 import { styles as modalStyles } from './connect';
 
@@ -90,16 +91,7 @@ export const ActionModal: React.FC<Props> = ({
 }: Props) => {
   const theme = useTheme();
   const { pendingActionCount, dapp } = useCeloInternal();
-
-  useEffect(() => {
-    if (pendingActionCount > 0) {
-      document.body.style.overflow = 'hidden';
-      document.body.style.paddingRight = '15px';
-    } else {
-      document.body.style.overflow = 'unset';
-      document.body.style.paddingRight = '0px';
-    }
-  }, [pendingActionCount]);
+  useFixedBody(pendingActionCount > 0);
 
   return (
     <ReactModal

--- a/packages/react-celo/src/modals/action.tsx
+++ b/packages/react-celo/src/modals/action.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode } from 'react';
 import { isMobile } from 'react-device-detect';
 import ReactModal from 'react-modal';
 

--- a/packages/react-celo/src/modals/action.tsx
+++ b/packages/react-celo/src/modals/action.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { isMobile } from 'react-device-detect';
 import ReactModal from 'react-modal';
 
@@ -90,6 +90,16 @@ export const ActionModal: React.FC<Props> = ({
 }: Props) => {
   const theme = useTheme();
   const { pendingActionCount, dapp } = useCeloInternal();
+
+  useEffect(() => {
+    if (pendingActionCount > 0) {
+      document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = '15px';
+    } else {
+      document.body.style.overflow = 'unset';
+      document.body.style.paddingRight = '0px';
+    }
+  }, [pendingActionCount]);
 
   return (
     <ReactModal

--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -1,7 +1,6 @@
 import React, {
   FunctionComponent,
   useCallback,
-  useEffect,
   useMemo,
   useState,
 } from 'react';

--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -1,6 +1,7 @@
 import React, {
   FunctionComponent,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -124,6 +125,16 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
     },
     [back, connectionCallback]
   );
+
+  useEffect(() => {
+    if (!!connectionCallback) {
+      document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = '15px';
+    } else {
+      document.body.style.overflow = 'unset';
+      document.body.style.paddingRight = '0px';
+    }
+  }, [connectionCallback]);
 
   const {
     hideFromDefaults,

--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -127,7 +127,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   );
 
   useEffect(() => {
-    if (!!connectionCallback) {
+    if (connectionCallback) {
       document.body.style.overflow = 'hidden';
       document.body.style.paddingRight = '15px';
     } else {

--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -25,6 +25,7 @@ import {
 } from '../types';
 import { useCeloInternal } from '../use-celo';
 import { hexToRGB } from '../utils/colors';
+import { useFixedBody } from '../utils/helpers';
 import { defaultProviderSort, SortingPredicate } from '../utils/sort';
 import cls from '../utils/tailwind';
 
@@ -126,16 +127,6 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
     [back, connectionCallback]
   );
 
-  useEffect(() => {
-    if (connectionCallback) {
-      document.body.style.overflow = 'hidden';
-      document.body.style.paddingRight = '15px';
-    } else {
-      document.body.style.overflow = 'unset';
-      document.body.style.paddingRight = '0px';
-    }
-  }, [connectionCallback]);
-
   const {
     hideFromDefaults,
     additionalWCWallets,
@@ -185,6 +176,8 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   ) : (
     <Placeholder />
   );
+
+  useFixedBody(!!connectionCallback);
 
   return (
     <ReactModal

--- a/packages/react-celo/src/utils/helpers.ts
+++ b/packages/react-celo/src/utils/helpers.ts
@@ -97,14 +97,13 @@ export function isValidFeeCurrency(currency: Maybe<string>): boolean {
 export function useFixedBody(isOpen: boolean) {
   useEffect(() => {
     if (isOpen) {
-      const x = window.scrollX;
-      const y = window.scrollY;
-      const disableScroll = () => {
-        window.scrollTo(x, y);
-      };
-      window.addEventListener('scroll', disableScroll);
+      const originalOverflow = document.body.style.overflow;
+      const originalPadding = document.body.style.paddingRight;
+      document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = '15px';
       return () => {
-        window.removeEventListener('scroll', disableScroll);
+        document.body.style.overflow = originalOverflow;
+        document.body.style.paddingRight = originalPadding;
       };
     }
   }, [isOpen]);

--- a/packages/react-celo/src/utils/helpers.ts
+++ b/packages/react-celo/src/utils/helpers.ts
@@ -97,11 +97,15 @@ export function isValidFeeCurrency(currency: Maybe<string>): boolean {
 export function useFixedBody(isOpen: boolean) {
   useEffect(() => {
     if (isOpen) {
-      document.body.style.overflow = 'hidden';
-      document.body.style.paddingRight = '15px';
-    } else {
-      document.body.style.overflow = 'unset';
-      document.body.style.paddingRight = '0px';
+      const x = window.scrollX;
+      const y = window.scrollY;
+      const disableScroll = () => {
+        window.scrollTo(x, y);
+      };
+      window.addEventListener('scroll', disableScroll);
+      return () => {
+        window.removeEventListener('scroll', disableScroll);
+      };
     }
   }, [isOpen]);
 }

--- a/packages/react-celo/src/utils/helpers.ts
+++ b/packages/react-celo/src/utils/helpers.ts
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
 import { CeloContract, CeloTokenContract } from '@celo/contractkit/lib/base';
+import { useEffect } from 'react';
 
 import { CONNECTOR_TYPES, UnauthenticatedConnector } from '../connectors';
 import { localStorageKeys, WalletTypes } from '../constants';

--- a/packages/react-celo/src/utils/helpers.ts
+++ b/packages/react-celo/src/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { CeloContract, CeloTokenContract } from '@celo/contractkit/lib/base';
 
 import { CONNECTOR_TYPES, UnauthenticatedConnector } from '../connectors';
@@ -91,4 +92,16 @@ export function isValidFeeCurrency(currency: Maybe<string>): boolean {
     default:
       return false;
   }
+}
+
+export function useFixedBody(isOpen: boolean) {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = '15px';
+    } else {
+      document.body.style.overflow = 'unset';
+      document.body.style.paddingRight = '0px';
+    }
+  }, [isOpen]);
 }


### PR DESCRIPTION
Fixes #202

Previously, background could be scrolled while modal is open. This PR disables it for the connect modal and action modal.