### PR TITLE
Fixes some external issues with styles being set on elements 

### DIFF
--- a/packages/react-celo/src/modals/action.tsx
+++ b/packages/react-celo/src/modals/action.tsx
@@ -94,6 +94,8 @@ export const ActionModal: React.FC<Props> = ({
   return (
     <ReactModal
       portalClassName={styles.portal}
+      htmlOpenClassName={'react-celo-modal-open-html'}
+      bodyOpenClassName={'react-celo-modal-open-body'}
       isOpen={pendingActionCount > 0}
       // isOpen
       ariaHideApp={false}

--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -178,6 +178,8 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   return (
     <ReactModal
       portalClassName={styles.portal}
+      htmlOpenClassName={'react-celo-modal-open-html'}
+      bodyOpenClassName={'react-celo-modal-open-body'}
       isOpen={!!connectionCallback}
       onRequestClose={close}
       className={styles.modal}

--- a/packages/react-celo/src/styles.css
+++ b/packages/react-celo/src/styles.css
@@ -531,7 +531,7 @@ Add the correct display in Chrome and Safari.
   height: auto;
 }
 
-/* 
+/*
 Scrollbar overrides
 ===================
 */
@@ -627,14 +627,17 @@ Spinner
 @tailwind components;
 @tailwind utilities;
 
-body {
+.react-celo-modal-open-body {
   min-height: 100vh;
   /* mobile viewport bug fix */
   min-height: -webkit-fill-available;
+  overflow: hidden;
 }
 
-html {
-  height: -webkit-fill-available;
+@media (max-width: 900px) {
+  .react-celo-modal-open-html {
+    height: -webkit-fill-available;
+  }
 }
 
 * {


### PR DESCRIPTION
previously to fix an issue on iOS with modal height we added -webkit-fill-available to html. however this causes gradient backgrounds with no repeat set to end at the window height rather than extend down the desktop. 

THE SOLUTION

use react modals custom classname to add the styles to html and body only when our modal is open

fixes. #268