### PR TITLE
Fix handling of reactModalProp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+      - stable
+      - 'release/**'
 
 jobs:
   build:

--- a/packages/react-celo/__tests__/modals/connect.test.tsx
+++ b/packages/react-celo/__tests__/modals/connect.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+
+import React from 'react';
+
+import { ConnectModal } from '../../src/modals';
+import { renderComponentInCKProvider } from '../render-in-provider';
+
+renderComponentInCKProvider;
+
+describe('ConnectModal', () => {
+  describe('when given reactModalProps', () => {
+    describe('style.overlay', () => {
+      it('applies those styles', async () => {
+        const dom = renderComponentInCKProvider(
+          <ConnectModal
+            reactModalProps={{
+              isOpen: true,
+              style: { overlay: { zIndex: 10 } },
+            }}
+          />,
+          { providerProps: {} }
+        );
+        const modal = await dom.findByRole('dialog');
+        expect(modal.parentElement).toHaveStyle('z-index: 10');
+      });
+    });
+  });
+});

--- a/packages/react-celo/__tests__/modals/connect.test.tsx
+++ b/packages/react-celo/__tests__/modals/connect.test.tsx
@@ -1,27 +1,46 @@
 import '@testing-library/jest-dom';
 
+import { RenderResult } from '@testing-library/react';
 import React from 'react';
 
 import { ConnectModal } from '../../src/modals';
 import { renderComponentInCKProvider } from '../render-in-provider';
 
-renderComponentInCKProvider;
+const theme = {
+  primary: '#eef2ff',
+  secondary: '#6366f1',
+  text: '#ffffff',
+  textSecondary: '#cbd5e1',
+  textTertiary: '#64748b',
+  muted: '#334155',
+  background: '#1e293b',
+  error: '#ef4444',
+};
 
 describe('ConnectModal', () => {
   describe('when given reactModalProps', () => {
+    let dom: RenderResult;
     describe('style.overlay', () => {
-      it('applies those styles', async () => {
-        const dom = renderComponentInCKProvider(
+      beforeEach(() => {
+        dom = renderComponentInCKProvider(
           <ConnectModal
             reactModalProps={{
               isOpen: true,
               style: { overlay: { zIndex: 10 } },
             }}
           />,
-          { providerProps: {} }
+          { providerProps: { theme } }
         );
+      });
+      it('applies those styles while keeping original', async () => {
         const modal = await dom.findByRole('dialog');
-        expect(modal.parentElement).toHaveStyle('z-index: 10');
+        expect(modal.parentElement).toHaveStyle(
+          'z-index: 10; background: rgba(30, 41, 59, 0.75)'
+        );
+      });
+      it('still uses theme for background on content modal', async () => {
+        const modal = await dom.findByRole('dialog');
+        expect(modal).toHaveStyle('background: rgba(30, 41, 59, 1)');
       });
     });
   });

--- a/packages/react-celo/__tests__/react-celo-provider.test.tsx
+++ b/packages/react-celo/__tests__/react-celo-provider.test.tsx
@@ -1,51 +1,17 @@
 import '@testing-library/jest-dom';
 
 import { CeloContract } from '@celo/contractkit';
-import { act, fireEvent, render, renderHook } from '@testing-library/react';
-import React, { ReactElement } from 'react';
+import { act, fireEvent } from '@testing-library/react';
+import React from 'react';
 
 import { Mainnet, SupportedProviders } from '../src/constants';
-import { CeloProvider, CeloProviderProps } from '../src/react-celo-provider';
+import { CeloProviderProps } from '../src/react-celo-provider';
 import { Maybe, Network, Theme } from '../src/types';
 import { UseCelo, useCelo, useCeloInternal } from '../src/use-celo';
-
-interface RenderArgs {
-  providerProps: Partial<CeloProviderProps>;
-}
-
-const defaultProps: CeloProviderProps = {
-  dapp: {
-    name: 'Testing Celo React',
-    description: 'Test it well',
-    url: 'https://celo.developers',
-    icon: '',
-  },
-  children: null,
-};
-
-function renderHookInCKProvider<R>(
-  hook: (i: unknown) => R,
-  { providerProps }: RenderArgs
-) {
-  return renderHook<R, unknown>(hook, {
-    wrapper: ({ children }) => {
-      const props = { ...defaultProps, ...providerProps };
-      return <CeloProvider {...props}>{children}</CeloProvider>;
-    },
-  });
-}
-
-function renderComponentInCKProvider(
-  ui: ReactElement<unknown, string>,
-  { providerProps }: RenderArgs
-) {
-  return render(ui, {
-    wrapper: ({ children }) => {
-      const props = { ...defaultProps, ...providerProps };
-      return <CeloProvider {...props}>{children}</CeloProvider>;
-    },
-  });
-}
+import {
+  renderComponentInCKProvider,
+  renderHookInCKProvider,
+} from './render-in-provider';
 
 describe('CeloProvider', () => {
   describe('user interface', () => {

--- a/packages/react-celo/__tests__/render-in-provider.tsx
+++ b/packages/react-celo/__tests__/render-in-provider.tsx
@@ -1,0 +1,42 @@
+import { render, renderHook } from '@testing-library/react';
+import React, { ReactElement } from 'react';
+
+import { CeloProvider, CeloProviderProps } from '../src/react-celo-provider';
+
+interface RenderArgs {
+  providerProps: Partial<CeloProviderProps>;
+}
+
+const defaultProps: CeloProviderProps = {
+  dapp: {
+    name: 'Testing Celo React',
+    description: 'Test it well',
+    url: 'https://celo.developers',
+    icon: '',
+  },
+  children: null,
+};
+
+export function renderComponentInCKProvider(
+  ui: ReactElement<unknown, string>,
+  { providerProps }: RenderArgs
+) {
+  return render(ui, {
+    wrapper: ({ children }) => {
+      const props = { ...defaultProps, ...providerProps };
+      return <CeloProvider {...props}>{children}</CeloProvider>;
+    },
+  });
+}
+
+export function renderHookInCKProvider<R>(
+  hook: (i: unknown) => R,
+  { providerProps }: RenderArgs
+) {
+  return renderHook<R, unknown>(hook, {
+    wrapper: ({ children }) => {
+      const props = { ...defaultProps, ...providerProps };
+      return <CeloProvider {...props}>{children}</CeloProvider>;
+    },
+  });
+}

--- a/packages/react-celo/package.json
+++ b/packages/react-celo/package.json
@@ -29,7 +29,7 @@
     "@celo/wallet-ledger": "^2.0.0",
     "@celo/wallet-local": "^2.0.0",
     "@celo/wallet-remote": "^2.0.0",
-    "@celo/wallet-walletconnect-v1": "4.0.1-beta.1",
+    "@celo/wallet-walletconnect-v1": "4.0.1-beta.1-dev",
     "@ethersproject/providers": "^5.5.2",
     "@ledgerhq/hw-transport-webusb": "^5.43.0",
     "isomorphic-fetch": "^3.0.0",

--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -57,6 +57,11 @@ export const styles = cls({
     tw-overflow-hidden`,
 });
 
+type ReactModalProps = Omit<
+  ReactModal.Props,
+  'onRequestClose' | 'htmlOpenClassName' | 'bodyOpenClassName'
+>;
+
 export interface ConnectModalProps {
   screens?: {
     [x in SupportedProviders]?: FunctionComponent<{
@@ -69,7 +74,7 @@ export interface ConnectModalProps {
     onClick: () => void;
     selected: boolean;
   }>;
-  reactModalProps?: Partial<ReactModal.Props>;
+  reactModalProps?: Partial<ReactModalProps>;
   title?: string | React.ReactElement;
   providersOptions?: {
     hideFromDefaults?: true | SupportedProviders[];
@@ -194,10 +199,13 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
       className={styles.modal}
       overlayClassName={styles.overlay}
       style={{
+        ...reactModalProps?.style,
         content: {
+          ...reactModalProps?.style?.content,
           background: theme.background,
         },
         overlay: {
+          ...reactModalProps?.style?.overlay,
           background: hexToRGB(theme.background, 0.75),
         },
       }}

--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -195,21 +195,19 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
       htmlOpenClassName={'react-celo-modal-open-html'}
       bodyOpenClassName={'react-celo-modal-open-body'}
       isOpen={!!connectionCallback}
-      onRequestClose={close}
       className={styles.modal}
       overlayClassName={styles.overlay}
+      {...reactModalProps}
+      onRequestClose={close}
       style={{
-        ...reactModalProps?.style,
         content: {
-          ...reactModalProps?.style?.content,
           background: theme.background,
         },
         overlay: {
-          ...reactModalProps?.style?.overlay,
           background: hexToRGB(theme.background, 0.75),
+          ...reactModalProps?.style?.overlay,
         },
       }}
-      {...reactModalProps}
       shouldCloseOnOverlayClick={!isMobile}
       ariaHideApp={false}
     >


### PR DESCRIPTION
Ensures that apps can pass in a z-index to the overlay to ensure the modal is placed above their elements. 


Also makesure they cant pass in onRequestClose as that would break our functionality 