### PR TITLE
Fix style bugs

### DIFF
--- a/packages/react-celo/src/components/tray.tsx
+++ b/packages/react-celo/src/components/tray.tsx
@@ -24,6 +24,7 @@ function priorityToText(priority: Priorities) {
 }
 
 const styles = cls({
+  spacer: `tw-h-10`,
   title: `
     tw-pb-2
     tw-text-md
@@ -46,7 +47,6 @@ const styles = cls({
     tw-overflow-y-auto
     tw-overflow-x-hidden
     tw-overscroll-contain
-    tw-min-h-full
     tw-pr-1`,
   subtitle: `
     tw-font-medium
@@ -155,7 +155,7 @@ export default function Tray({
   return (
     <>
       <div className={styles.verticalContainer}>
-        <div className={styles.scrollableList}>
+        <div className={`${styles.scrollableList} rc-tray-ios-fix`}>
           <div
             className={styles.title}
             style={{ color: theme.textSecondary, background: theme.background }}
@@ -201,6 +201,8 @@ export default function Tray({
                     />
                   );
                 })}
+                {/* add spacer  to ensure there is room below to push up the last wallet from being hidden by ios tool bars etc. this is better than decreasing height as it just adds whitespace instead of taking away screen space*/}
+                {isMobile && <span className={styles.spacer} />}
               </div>
             </div>
           ))}

--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -23,11 +23,7 @@ import { defaultProviderSort, SortingPredicate } from '../utils/sort';
 import cls from '../utils/tailwind';
 
 export const styles = cls({
-  overlay: isMobile
-    ? `
-      tw-fixed
-      tw-inset-0`
-    : `
+  overlay: `z-40
       tw-fixed
       tw-inset-0`,
   modal: isMobile

--- a/packages/react-celo/src/styles.css
+++ b/packages/react-celo/src/styles.css
@@ -441,9 +441,12 @@ Spinner
   .react-celo-modal-open-html {
     height: -webkit-fill-available;
   }
+  .rc-tray-ios-fix {
+    height: -webkit-fill-available;
+  }
 }
 @media (min-width: 900px) {
-  .react-celo-modal-open-html {
+  .react-celo-modal-open-body {
     min-height: 100vh;
     max-height: 100vh;
   }

--- a/packages/react-celo/src/styles.css
+++ b/packages/react-celo/src/styles.css
@@ -433,15 +433,19 @@ Spinner
 @tailwind utilities;
 
 .react-celo-modal-open-body {
-  min-height: 100vh;
-  /* mobile viewport bug fix */
-  min-height: -webkit-fill-available;
+  height: -webkit-fill-available;
   overflow: hidden;
 }
 
 @media (max-width: 900px) {
   .react-celo-modal-open-html {
     height: -webkit-fill-available;
+  }
+}
+@media (min-width: 900px) {
+  .react-celo-modal-open-html {
+    min-height: 100vh;
+    max-height: 100vh;
   }
 }
 


### PR DESCRIPTION
Fix background gradient while modal open (avoid setting min-height on body for desktop sizes)
Fix list of wallets hiding last wallet on ios (now has extra bottom padding)
Fix default stacking order being too low  (now zIndex is 40) this can also be [modified](https://github.com/celo-org/react-celo/discussions/292)


## example of background gradients when modal is open on various browsers

<img width="1425" alt="Screen Shot 2022-08-03 at 11 58 19 AM" src="https://user-images.githubusercontent.com/3814795/182581903-7165a76e-4044-424b-983b-b6326c3417f0.png">
<img width="1305" alt="Screen Shot 2022-08-03 at 12 00 27 PM" src="https://user-images.githubusercontent.com/3814795/182581913-8252d87c-82ae-4409-84a8-1b89f364841c.png">
<img width="1440" alt="Screen Shot 2022-08-03 at 12 00 42 PM" src="https://user-images.githubusercontent.com/3814795/182581916-90c3f1d2-56bd-4b53-b31f-677f32272ff1.png">
