### PR TITLE
Fix improper error when metamask gets locked

### DIFF
--- a/packages/react-celo/src/connectors/injected.ts
+++ b/packages/react-celo/src/connectors/injected.ts
@@ -104,8 +104,13 @@ export default class InjectedConnector
   };
 
   private onAccountsChanged = (accounts: string[]) => {
-    this.kit.connection.defaultAccount = accounts[0];
-    this.emit(ConnectorEvents.ADDRESS_CHANGED, accounts[0]);
+    if (accounts.length === 0) {
+      // wallet is locked properly close the connection.
+      this.close();
+    } else {
+      this.kit.connection.defaultAccount = accounts[0];
+      this.emit(ConnectorEvents.ADDRESS_CHANGED, accounts[0]);
+    }
   };
 
   supportsFeeCurrency() {

--- a/packages/react-celo/src/global.d.ts
+++ b/packages/react-celo/src/global.d.ts
@@ -24,6 +24,8 @@ interface Ethereum extends Exclude<AbstractProvider, 'request'> {
   on: AddEthereumEventListener;
   removeListener: RemoveEthereumEventListener;
   isMetaMask?: boolean;
+  isConnected: () => boolean;
+  selectedAddress: string | undefined;
   request: EthereumRequest;
   enable: () => Promise<void>;
 }


### PR DESCRIPTION
When a user locks their metamask it emits the accountsChanged event with an empty array. 

Previously this was causing react-celo to error and improperly disconnect. 

Now it handles disconnecting with grace. 


This mirrors behavior seen on daps such as uniswap and on the rainbowkit. 


also adjusts the Ethereum object to have some properties missing from the type