### PR TITLE
Fix regression  metamask network regression

### DIFF
--- a/packages/react-celo/src/connectors/coinbase-wallet.ts
+++ b/packages/react-celo/src/connectors/coinbase-wallet.ts
@@ -13,7 +13,7 @@ import { WalletTypes } from '../constants';
 import { Ethereum } from '../global';
 import { Connector, Dapp, Network } from '../types';
 import { getApplicationLogger } from '../utils/logger';
-import { switchToCeloNetwork } from '../utils/metamask';
+import { switchToNetwork } from '../utils/metamask';
 import { AbstractConnector, ConnectorEvents, Web3Type } from './common';
 
 export default class CoinbaseWalletConnector
@@ -72,7 +72,7 @@ export default class CoinbaseWalletConnector
 
     this.removeListeners();
 
-    await switchToCeloNetwork(
+    await switchToNetwork(
       this.network,
       this.provider as unknown as Ethereum,
       () => web3.eth.getChainId()
@@ -125,10 +125,8 @@ export default class CoinbaseWalletConnector
   }
   async startNetworkChangeFromApp(network: Network) {
     const web3 = this.kit.connection.web3;
-    await switchToCeloNetwork(
-      network,
-      this.provider! as unknown as Ethereum,
-      () => web3.eth.getChainId()
+    await switchToNetwork(network, this.provider! as unknown as Ethereum, () =>
+      web3.eth.getChainId()
     );
     this.continueNetworkUpdateFromWallet(network);
   }

--- a/packages/react-celo/src/connectors/injected.ts
+++ b/packages/react-celo/src/connectors/injected.ts
@@ -9,7 +9,7 @@ import { WalletTypes } from '../constants';
 import { Connector, Network } from '../types';
 import { getEthereum, getInjectedEthereum } from '../utils/ethereum';
 import { getApplicationLogger } from '../utils/logger';
-import { switchToCeloNetwork } from '../utils/metamask';
+import { switchToNetwork } from '../utils/metamask';
 import { AbstractConnector, ConnectorEvents, Web3Type } from './common';
 
 export default class InjectedConnector
@@ -51,7 +51,7 @@ export default class InjectedConnector
 
     ethereum.removeListener('chainChanged', this.onChainChanged);
     ethereum.removeListener('accountsChanged', this.onAccountsChanged);
-    await switchToCeloNetwork(this.network, ethereum, () =>
+    await switchToNetwork(this.network, ethereum, () =>
       this.kit.connection.chainId()
     );
     ethereum.on('chainChanged', this.onChainChanged);
@@ -77,7 +77,7 @@ export default class InjectedConnector
 
   async startNetworkChangeFromApp(network: Network) {
     const ethereum = getEthereum();
-    await switchToCeloNetwork(network, ethereum!, this.kit.connection.chainId);
+    await switchToNetwork(network, ethereum!, this.kit.connection.chainId);
     this.continueNetworkUpdateFromWallet(network);
   }
 

--- a/packages/react-celo/src/global.d.ts
+++ b/packages/react-celo/src/global.d.ts
@@ -28,6 +28,7 @@ interface Ethereum extends Exclude<AbstractProvider, 'request'> {
   selectedAddress: string | undefined;
   request: EthereumRequest;
   enable: () => Promise<void>;
+  chainId?: string;
 }
 
 type AddEthereumEventListener = <Event extends keyof EthereumEventCallbacks>(
@@ -55,6 +56,7 @@ interface EthereumRequestReturns {
   wallet_addEthereumChain: null;
   wallet_watchAsset: boolean;
   wallet_switchEthereumChain: null;
+  eth_chainId: string;
 }
 
 interface BitMatrix {


### PR DESCRIPTION
Returns back behavior of switching metamask to dapp's default network on initialise. This was accidentally broken by refactor. 

note that  in future another version may make this behavior optional but not not so as of yet. 


## other changes
* also fix token import to metamask to use new mento uri for logo
* change function name to be generic rather than specific to celo.