### PR TITLE
Feat #294 show up to 3 most recent wallets used

### DIFF
--- a/packages/react-celo/__tests__/utils/local-storage.test.ts
+++ b/packages/react-celo/__tests__/utils/local-storage.test.ts
@@ -92,12 +92,12 @@ describe('rememberWallet', () => {
     it('adds it and removes last item', () => {
       rememberWallet(WalletTypes.Valora, WalletIds.Valora);
       rememberWallet(WalletTypes.MetaMask);
-      rememberWallet(WalletTypes.WalletConnect, WalletIds.Steakwallet);
+      rememberWallet(WalletTypes.WalletConnect, WalletIds.Omni);
       rememberWallet(WalletTypes.CeloTerminal, WalletIds.CeloTerminal);
 
       expect(getRecentWallets()).toEqual([
         `${WalletTypes.CeloTerminal}:${WalletIds.CeloTerminal}`,
-        `${WalletTypes.WalletConnect}:${WalletIds.Steakwallet}`,
+        `${WalletTypes.WalletConnect}:${WalletIds.Omni}`,
         WalletTypes.MetaMask,
       ]);
     });

--- a/packages/react-celo/__tests__/utils/local-storage.test.ts
+++ b/packages/react-celo/__tests__/utils/local-storage.test.ts
@@ -1,12 +1,18 @@
 import { CeloContract } from '@celo/contractkit';
 
-import { localStorageKeys, WalletTypes } from '../../src/constants';
+import { localStorageKeys, WalletIds, WalletTypes } from '../../src/constants';
 import {
+  getRecentWallets,
   getTypedStorageKey,
+  rememberWallet,
   setTypedStorageKey,
+  wipeStorage,
 } from '../../src/utils/local-storage';
 
 describe('TypedLocalStorage', () => {
+  beforeEach(() => {
+    wipeStorage();
+  });
   describe('get/setTypedStorageKey', () => {
     describe(localStorageKeys.lastUsedAddress, () => {
       it('sets Address', () => {
@@ -37,6 +43,63 @@ describe('TypedLocalStorage', () => {
           getTypedStorageKey(localStorageKeys.lastUsedFeeCurrency)
         ).toEqual(CeloContract.StableTokenBRL);
       });
+    });
+  });
+});
+
+describe('getRecentWallets', () => {
+  beforeEach(() => {
+    wipeStorage();
+  });
+  it('returns an empty array when nothing is there', () => {
+    expect(getRecentWallets()).toEqual([]);
+  });
+  it('returns array of {type} strings when they have been added', () => {
+    setTypedStorageKey(
+      localStorageKeys.lastUsedWallets,
+      JSON.stringify([`${WalletTypes.MetaMask}`])
+    );
+    expect(getRecentWallets()).toEqual([WalletTypes.MetaMask]);
+  });
+});
+
+describe('rememberWallet', () => {
+  beforeEach(() => {
+    wipeStorage();
+  });
+  describe('when storing for first time', () => {
+    it('saves it', () => {
+      rememberWallet(WalletTypes.Valora, WalletIds.Valora);
+      expect(getRecentWallets()).toEqual([
+        `${WalletTypes.Valora}:${WalletIds.Valora}`,
+      ]);
+    });
+  });
+  describe('when storing A BA C', () => {
+    it('will be storing B A C', () => {
+      rememberWallet(WalletTypes.Valora, WalletIds.Valora);
+      rememberWallet(WalletTypes.MetaMask);
+      rememberWallet(WalletTypes.Valora, WalletIds.Valora);
+      rememberWallet(WalletTypes.CeloTerminal, WalletIds.CeloTerminal);
+      expect(getRecentWallets()).toEqual([
+        `${WalletTypes.CeloTerminal}:${WalletIds.CeloTerminal}`,
+        `${WalletTypes.Valora}:${WalletIds.Valora}`,
+        WalletTypes.MetaMask,
+      ]);
+    });
+  });
+  describe('when at max size', () => {
+    it('adds it and removes last item', () => {
+      rememberWallet(WalletTypes.Valora, WalletIds.Valora);
+      rememberWallet(WalletTypes.MetaMask);
+      rememberWallet(WalletTypes.WalletConnect, WalletIds.Steakwallet);
+      rememberWallet(WalletTypes.CeloTerminal, WalletIds.CeloTerminal);
+
+      expect(getRecentWallets()).toEqual([
+        `${WalletTypes.CeloTerminal}:${WalletIds.CeloTerminal}`,
+        `${WalletTypes.WalletConnect}:${WalletIds.Steakwallet}`,
+        WalletTypes.MetaMask,
+      ]);
     });
   });
 });

--- a/packages/react-celo/__tests__/utils/persistor.test.ts
+++ b/packages/react-celo/__tests__/utils/persistor.test.ts
@@ -71,7 +71,10 @@ describe('Persistor', () => {
       expect(getTypedStorageKey(localStorageKeys.lastUsedWalletId)).toEqual(
         WalletIds.Omni
       );
-      expect(getRecent()).toEqual(PROVIDERS.Omni);
+      expect(getRecent()).toEqual({
+        providers: [PROVIDERS.Omni],
+        ids: new Set([`${WalletTypes.WalletConnect}:${WalletIds.Omni}`]),
+      });
     });
   });
   describe(`when connector emits ${ConnectorEvents.DISCONNECTED}`, () => {

--- a/packages/react-celo/src/components/icons/index.tsx
+++ b/packages/react-celo/src/components/icons/index.tsx
@@ -6,7 +6,7 @@ export { default as CoinbaseWallet } from './coinbase-wallet';
 export { default as Ethereum } from './ethereum';
 export { default as Ledger } from './ledger';
 export { default as MetaMask } from './metamask';
-export { default as PrivateKey } from './private-key';
 export { default as Omni } from './omni';
+export { default as PrivateKey } from './private-key';
 export { default as Valora } from './valora';
 export { default as WalletConnect } from './wallet-connect';

--- a/packages/react-celo/src/constants.tsx
+++ b/packages/react-celo/src/constants.tsx
@@ -15,11 +15,9 @@ export enum localStorageKeys {
   lastUsedNetwork = 'react-celo/last-used-network',
   lastUsedWalletType = 'react-celo/last-used-wallet',
   lastUsedWalletId = 'react-celo/last-used-wallet-id',
-
+  lastUsedWallets = 'react-celo/last-used-wallets',
   lastUsedIndex = 'react-celo/last-used-index',
   lastUsedPrivateKey = 'react-celo/last-used-private-key',
-
-  lastUsedWalletArguments = 'react-celo/last-used-wallet-arguments',
   lastUsedFeeCurrency = 'react-celo/last-used-fee-currency',
 }
 

--- a/packages/react-celo/src/hooks/use-providers.ts
+++ b/packages/react-celo/src/hooks/use-providers.ts
@@ -104,7 +104,6 @@ export default function useProviders(
     const recent = recentlyUsedProviders.providers.map((provider) => {
       return [provider.name, provider] as [string, Provider];
     });
-    console.info('recent', recent);
     const rest = providers.filter(([_, provider]) => {
       const unifiedID =
         provider.type === WalletTypes.WalletConnect

--- a/packages/react-celo/src/utils/local-storage.ts
+++ b/packages/react-celo/src/utils/local-storage.ts
@@ -58,8 +58,42 @@ type ParamType = {
   [localStorageKeys.lastUsedFeeCurrency]: CeloTokenContract;
   [localStorageKeys.lastUsedIndex]: number;
   [localStorageKeys.lastUsedWalletType]: WalletTypes;
-  [localStorageKeys.lastUsedWalletArguments]: [];
+  [localStorageKeys.lastUsedWallets]: string;
 };
+
+const MAX_WALLETS = 3;
+
+// adds wallet to top of stack
+// if stack already has wallet pull to top
+export function rememberWallet(type: WalletTypes, id?: string) {
+  const unifiedID = id ? `${type}:${id}` : type;
+  const stack = getRecentWallets();
+  const index = stack.indexOf(unifiedID);
+
+  if (index > -1) {
+    stack.splice(index, 1);
+  }
+
+  const newLength = stack.unshift(unifiedID);
+  if (newLength > MAX_WALLETS) {
+    // remove oldest
+    stack.pop();
+  }
+
+  const serialized = JSON.stringify(stack);
+
+  localStorage.setItem(localStorageKeys.lastUsedWallets, serialized);
+}
+
+export function getRecentWallets(): string[] {
+  const raw = localStorage.getItem(localStorageKeys.lastUsedWallets);
+  if (!raw) {
+    return [];
+  }
+  const stack = JSON.parse(raw) as string[];
+
+  return stack;
+}
 
 export function getTypedStorageKey<T extends localStorageKeys>(key: T) {
   const item = localStorage.getItem(key);
@@ -79,10 +113,6 @@ export function setTypedStorageKey<
   localStorage.setItem(key, value.toString());
 }
 
-export function removeLastUsedAddress() {
-  localStorage.removeItem(localStorageKeys.lastUsedAddress);
-}
-
 export type WalletArgs =
   | [string]
   | [CeloTokenContract]
@@ -90,23 +120,17 @@ export type WalletArgs =
   | [number]
   | [];
 
-export function getLastUsedWalletArgs(): WalletArgs | null {
-  const args = localStorage.getItem(localStorageKeys.lastUsedWalletArguments);
-  if (args && args.length) {
-    const parsed = JSON.parse(args) as WalletArgs;
-
-    return parsed;
-  }
-
-  return null;
-}
-
 export function clearPreviousConfig(): void {
   Object.values(localStorageKeys).forEach((val) => {
     if (val === localStorageKeys.lastUsedWalletId) return;
     if (val === localStorageKeys.lastUsedWalletType) return;
+    if (val === localStorageKeys.lastUsedWallets) return;
     localStorage.removeItem(val);
   });
+}
+
+export function wipeStorage() {
+  localStorage.clear();
 }
 
 export function localStorageAvailable() {

--- a/packages/react-celo/src/utils/local-storage.ts
+++ b/packages/react-celo/src/utils/local-storage.ts
@@ -86,7 +86,9 @@ export function rememberWallet(type: WalletTypes, id?: string) {
 }
 
 export function getRecentWallets(): string[] {
-  const raw = localStorage.getItem(localStorageKeys.lastUsedWallets);
+  const raw = localStorage.getItem(
+    localStorageKeys.lastUsedWallets as localStorageKeys.lastUsedWallets
+  );
   if (!raw) {
     return [];
   }

--- a/packages/react-celo/src/utils/persistor.ts
+++ b/packages/react-celo/src/utils/persistor.ts
@@ -1,7 +1,11 @@
 import { ConnectorEvents, ConnectorParams } from '../connectors/common';
 import { localStorageKeys } from '../constants';
 import { Connector } from '../types';
-import { clearPreviousConfig, setTypedStorageKey } from './local-storage';
+import {
+  clearPreviousConfig,
+  rememberWallet,
+  setTypedStorageKey,
+} from './local-storage';
 
 type Updater = (connector: Connector) => void;
 
@@ -25,6 +29,7 @@ const persistor: Updater = (connector: Connector) => {
     if (params.walletId) {
       setTypedStorageKey(localStorageKeys.lastUsedWalletId, params.walletId);
     }
+    rememberWallet(params.walletType, params.walletId);
   });
 
   connector.on(ConnectorEvents.DISCONNECTED, () => {


### PR DESCRIPTION
Rather than just remembering the most recent wallet remember the last 3. 


* three could be any number but seems a good medium between a long memory and just taking over the entire list
* list never duplicates wallets, and most recent is pulled to top if it was used already recently

<img width="355" alt="Screen Shot 2022-08-23 at 1 19 39 PM" src="https://user-images.githubusercontent.com/3814795/186147375-e6377f1b-174c-493b-a14b-aee8e613a35c.png">
