### PR TITLE
dont ask metamask to unlock if we are already connected and ressurecting

### DIFF
--- a/packages/react-celo/src/connectors/injected.ts
+++ b/packages/react-celo/src/connectors/injected.ts
@@ -49,7 +49,7 @@ export default class InjectedConnector
     this.type = isMetaMask ? WalletTypes.MetaMask : WalletTypes.Injected;
     const metamask = ethereum._metamask;
     const isUnlocked = isMetaMask && (await metamask?.isUnlocked());
-    const isConnected = ethereum.isConnected();
+    const isConnected = ethereum.isConnected && ethereum.isConnected();
     if (isUnlocked || !isConnected || !lastUsedAddress) {
       [defaultAccount] = await ethereum.request({
         method: 'eth_requestAccounts',

--- a/packages/react-celo/src/connectors/injected.ts
+++ b/packages/react-celo/src/connectors/injected.ts
@@ -47,7 +47,8 @@ export default class InjectedConnector
     const { web3, ethereum, isMetaMask } = injected;
 
     this.type = isMetaMask ? WalletTypes.MetaMask : WalletTypes.Injected;
-    const isUnlocked = isMetaMask && (await ethereum._metamask?.isUnlocked());
+    const metamask = ethereum._metamask;
+    const isUnlocked = isMetaMask && (await metamask?.isUnlocked());
     const isConnected = ethereum.isConnected();
     if (isUnlocked || !isConnected || !lastUsedAddress) {
       [defaultAccount] = await ethereum.request({

--- a/packages/react-celo/src/connectors/injected.ts
+++ b/packages/react-celo/src/connectors/injected.ts
@@ -50,7 +50,7 @@ export default class InjectedConnector
     const metamask = ethereum._metamask;
     const isUnlocked = isMetaMask && (await metamask?.isUnlocked());
     const isConnected = ethereum.isConnected && ethereum.isConnected();
-    if (isUnlocked || !isConnected || !lastUsedAddress) {
+    if (isUnlocked || !isConnected || !defaultAccount) {
       [defaultAccount] = await ethereum.request({
         method: 'eth_requestAccounts',
       });
@@ -66,7 +66,7 @@ export default class InjectedConnector
     ethereum.on('chainChanged', this.onChainChanged);
     ethereum.on('accountsChanged', this.onAccountsChanged);
 
-    this.newKit(web3 as unknown as Web3Type, defaultAccount as string);
+    this.newKit(web3 as unknown as Web3Type, defaultAccount);
 
     const walletChainId = await ethereum.request({ method: 'eth_chainId' });
 
@@ -74,7 +74,7 @@ export default class InjectedConnector
 
     this.emit(ConnectorEvents.CONNECTED, {
       walletType: this.type,
-      address: defaultAccount as string,
+      address: defaultAccount,
       networkName: this.network.name,
       walletChainId: parseInt(walletChainId, 16),
     });

--- a/packages/react-celo/src/global.d.ts
+++ b/packages/react-celo/src/global.d.ts
@@ -21,6 +21,9 @@ declare global {
 }
 
 interface Ethereum extends Exclude<AbstractProvider, 'request'> {
+  _metamask: {
+    isUnlocked: () => Promise<boolean>;
+  };
   on: AddEthereumEventListener;
   removeListener: RemoveEthereumEventListener;
   isMetaMask?: boolean;

--- a/packages/react-celo/src/react-celo-provider.tsx
+++ b/packages/react-celo/src/react-celo-provider.tsx
@@ -67,7 +67,7 @@ export const CeloProvider: React.FC<CeloProviderProps> = ({
   const methods = useCeloMethods(state, dispatch, buildContractsCache);
 
   // what happens when i disconnect, need to be able to switch chains still.
-  // need to init Unauthenticated connnector both at startup and when last chain was disconnected or Replace the null object pattern
+  // need to init Unauthenticated connector both at startup and when last chain was disconnected or Replace the null object pattern
   // benefit is that you might still want to just passively watch a chain
   // downside is there are some sementics that get weird
   useEffect(() => {
@@ -76,15 +76,17 @@ export const CeloProvider: React.FC<CeloProviderProps> = ({
       state.connector.type,
       'Connector'
     );
-    methods.initConnector(state.connector).catch(async (e) => {
-      getApplicationLogger().error(
-        'onLoad Initialisation Failed',
-        state.connector.type,
-        e
-      );
-      // If the connector fails to initialise on mount then we reset.
-      await methods.disconnect();
-    });
+    methods
+      .initConnector(state.connector, state.address as string)
+      .catch(async (e) => {
+        getApplicationLogger().error(
+          'onLoad Initialisation Failed',
+          state.connector.type,
+          e
+        );
+        // If the connector fails to initialise on mount then we reset.
+        await methods.disconnect();
+      });
     // We only want this to run on mount so the deps array is empty.
     /* eslint-disable-next-line */
   }, []);

--- a/packages/react-celo/src/types.ts
+++ b/packages/react-celo/src/types.ts
@@ -72,7 +72,7 @@ export interface Connector {
    * `initialise` loads the connector
    *  and saves it to local storage.
    */
-  initialise: () => Promise<this> | this;
+  initialise: (lastUsedAddress?: string) => Promise<this> | this;
   close: () => Promise<void> | void;
   on<E extends ConnectorEvents>(e: E, fn: (arg: EventsMap[E]) => void): void;
   updateFeeCurrency?: (token: CeloTokenContract) => Promise<void>;

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -36,7 +36,9 @@ export function useCeloMethods(
         updater(nextConnector, dispatch);
         persistor(nextConnector);
         networkWatcher(nextConnector, networks, manualNetworkMode);
-        const initialisedConnector = await nextConnector.initialise(lastUsedAddress);
+        const initialisedConnector = await nextConnector.initialise(
+          lastUsedAddress
+        );
         dispatch('initialisedConnector', initialisedConnector);
       } catch (e) {
         if (typeof e === 'symbol') {

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -30,13 +30,13 @@ export function useCeloMethods(
   buildContractsCache?: ContractCacheBuilder
 ): CeloMethods {
   const initConnector = useCallback(
-    async (nextConnector: Connector) => {
+    async (nextConnector: Connector, lastUsedAddress?: string) => {
       try {
         // need to set the event listeners here before initialise()
         updater(nextConnector, dispatch);
         persistor(nextConnector);
         networkWatcher(nextConnector, networks, manualNetworkMode);
-        const initialisedConnector = await nextConnector.initialise();
+        const initialisedConnector = await nextConnector.initialise(lastUsedAddress);
         dispatch('initialisedConnector', initialisedConnector);
       } catch (e) {
         if (typeof e === 'symbol') {
@@ -261,5 +261,8 @@ export interface CeloMethods {
    * `initConnector` is used to initialize a connector
    *  for the wallet chosen by the user.
    */
-  initConnector: (connector: Connector) => Promise<void>;
+  initConnector: (
+    connector: Connector,
+    lastUsedAddress?: string
+  ) => Promise<void>;
 }


### PR DESCRIPTION
When resurrecting metaMask and metaMask locked dont request the account (instead use the address found in local storage). This stops the need to unlock metaMask right away when loading the site. 


Fixes #295 