### PR TITLE
removed unnecessary github token secret in the workflow because there…

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,7 +9,6 @@ jobs:
     steps:
       - uses: github/issue-labeler@v2.4
         with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: .github/labeler.yml
           not-before: 2020-01-15T02:54:32Z
           enable-versioned-regex: 0


### PR DESCRIPTION
…'s no configured github secret in the repository anyways, so this doesn't do anything